### PR TITLE
fix(AHWR-1800): await payment status refresh in support flow #patch

### DIFF
--- a/app/routes/support/support-calls.js
+++ b/app/routes/support/support-calls.js
@@ -87,7 +87,7 @@ export const getPaymentDocument = async (claimReference, logger) => {
 };
 
 export const getPaymentDocumentWithRefresh = async (claimReference, logger) => {
-  makePostCall(
+  await makePostCall(
     `${paymentProxyApiUri}/support/payments/${claimReference}/request-status`,
     "No payment status found",
     logger,

--- a/app/routes/support/support-calls.test.js
+++ b/app/routes/support/support-calls.test.js
@@ -274,6 +274,28 @@ describe("getPaymentDocumentWithRefresh", () => {
       expect(mockLogger.error).toHaveBeenCalled();
     }
   });
+
+  it("propagates error and skips get when post fails with non-404", async () => {
+    const mockError = new Error("Request failed");
+    wreck.post = jest.fn().mockRejectedValue(mockError);
+    wreck.get = jest.fn();
+    try {
+      await getPaymentDocumentWithRefresh("123", mockLogger);
+      // This is to fail if no exception thrown
+      throw new Error("Expected getPaymentDocumentWithRefresh to throw");
+    } catch (error) {
+      expect(error).toBe(mockError);
+      expect(wreck.post).toHaveBeenCalledWith(
+        "http://ahwr-payment-proxy:3001/api/support/payments/123/request-status",
+        {
+          json: true,
+          headers: { "x-api-key": "something" },
+        },
+      );
+      expect(wreck.get).not.toHaveBeenCalled();
+      expect(mockLogger.error).toHaveBeenCalled();
+    }
+  });
 });
 
 describe("getPaymentDocument", () => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -8736,7 +8736,6 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,


### PR DESCRIPTION
## Summary
Fixes a correctness bug in the backoffice support payment status search where stale data was returned to support staff instead of the freshly retrieved payment document. Also eliminates a latent unhandled promise rejection that could crash the backoffice process when the payment-proxy returned an error.

## What Changed
- Payment status refresh is now awaited before reading the payment document, so support staff see the fresh data they expect.
- Errors from the refresh endpoint propagate cleanly as a 500 response rather than becoming an unhandled rejection at the process level.
- Added unit test coverage for the error propagation path.

## Why
The "refresh and return" helper used by the support search facility was firing the refresh request without awaiting it, then immediately reading the payment document. This meant staff saw the previous (pre-refresh) value while believing it had been freshly retrieved. A secondary symptom was that any non-404 error from the refresh endpoint became an unhandled promise rejection, which on the Node version used in production can terminate the process. The fix aligns the helper's behaviour with the contract its name implies.