### PR TITLE
feat(flags): (AHWR-1877) remove obsolete multiple herds flag question and column

### DIFF
--- a/app/api/flags.js
+++ b/app/api/flags.js
@@ -38,7 +38,7 @@ export async function createFlag(payload, appRef, logger) {
   try {
     const res = await wreck.post(endpoint, {
       json: true,
-      payload,
+      payload: { ...payload, appliesToMh: false },
       headers: { "x-api-key": apiKeys.backofficeUiApiKey },
     });
     await metricsCounter("flag_created");

--- a/app/routes/flags.js
+++ b/app/routes/flags.js
@@ -82,7 +82,6 @@ const postFlagHandler = {
             then: Joi.object({
               appRef: Joi.string().min(MIN_APPLICATION_REFERENCE_LENGTH).required(),
               note: Joi.string().min(MIN_NOTE_LENGTH).required(),
-              appliesToMh: Joi.string().valid("yes", "no").required(),
               action: Joi.string().required(),
             }),
           },
@@ -115,14 +114,6 @@ const postFlagHandler = {
                 ...receivedError,
                 message: "Enter a valid agreement reference.",
                 href: AGREEMENT_REFERENCE,
-              };
-            }
-
-            if (receivedError.message.includes("appliesToMh")) {
-              return {
-                ...receivedError,
-                message: "Select if the flag is because the user declined multiple herds T&C's.",
-                href: "#appliesToMh",
               };
             }
 
@@ -182,11 +173,10 @@ const deleteFlagHandler = async (request, h) => {
 const createFlagHandler = async (request, h) => {
   try {
     const { name: userName } = request.auth.credentials.account;
-    const { note, appliesToMh, appRef } = request.payload;
+    const { note, appRef } = request.payload;
     const payload = {
       user: userName,
       note: note.trim(),
-      appliesToMh: appliesToMh === "yes",
     };
 
     const { res } = await createFlagApiCall(payload, appRef.trim(), request.logger);
@@ -224,7 +214,7 @@ const createFlagHandler = async (request, h) => {
     if (error.data.res.statusCode === StatusCodes.NO_CONTENT) {
       formattedErrors = [
         {
-          message: `Flag not created - agreement flag with the same "Flag applies to multiple herds T&C's" value already exists.`,
+          message: "This agreement already has an active flag.",
           path: [],
           type: STRING_EMPTY,
           context: {

--- a/app/routes/models/flags-list.js
+++ b/app/routes/models/flags-list.js
@@ -36,9 +36,6 @@ const createRows = (flags, isAdmin) => {
       {
         text: formatDate(flag.createdAt),
       },
-      {
-        text: flag.appliesToMh === true ? "Yes" : "No",
-      },
       ...(isAdmin && isAgreementNotRedacted
         ? [
             {
@@ -67,9 +64,6 @@ const createTableHeader = (isAdmin) => {
     {
       text: "Created at",
     },
-    {
-      text: "Flagged due to multiple herds",
-    },
     ...(isAdmin
       ? [
           {
@@ -86,10 +80,6 @@ export const createFlagsTableData = async ({ logger, flagIdToDelete, createFlag,
   const applicationRefOfFlagToDelete = flagIdToDelete
     ? flags.find((flag) => flag.id === flagIdToDelete).applicationReference
     : undefined;
-  const flagIsForMh = flagIdToDelete
-    ? flags.find((flag) => flag.id === flagIdToDelete).appliesToMh
-    : undefined;
-  const appliesToMh = flagIsForMh ? "multiple herds T&C's" : "non-MH";
 
   return {
     model: {
@@ -97,7 +87,6 @@ export const createFlagsTableData = async ({ logger, flagIdToDelete, createFlag,
       rows: createRows(flags, isAdmin),
       flagIdToDelete,
       applicationRefOfFlagToDelete,
-      appliesToMh,
       createFlagUrl: `${serviceUri}/flags?createFlag=true`,
       createFlag,
     },

--- a/app/views/includes/create-flag.njk
+++ b/app/views/includes/create-flag.njk
@@ -1,12 +1,10 @@
 {% from "govuk/components/textarea/macro.njk" import govukTextarea %}
 {% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
-{% from "govuk/components/inset-text/macro.njk" import govukInsetText %}
 
 <div class="govuk-panel govuk-grid-column-two-thirds govuk-panel--confirmation govuk-!-text-align-left" id="create-flag">
     <form method="POST" action="/flags" class="ahwr-update-form">
       <a href="/flags" class="govuk-link govuk-body">Back</a>
-      <h1 class="govuk-heading-xl govuk-!-margin-top-2 govuk-!-margin-bottom-2">Create flag</h1>
-      <span class="govuk-caption-xl govuk-!-margin-bottom-7">An agreement can have a maximum of 2 flags; one for multiple herds T&C's and one for any other reason.</span>
+      <h1 class="govuk-heading-xl govuk-!-margin-top-2 govuk-!-margin-bottom-7">Create flag</h1>
 
       {% if errors.length %}
         {{ govukErrorSummary({
@@ -14,10 +12,6 @@
             errorList: errors
         }) }}
       {% endif %}
-
-      {{ govukInsetText({
-        text: "If an agreement is flagged for not agreeing to multiple herds T&C's, when the owner of that agreement makes a claim they will not see the multiple herds pages and will not be able to claim for multiple herds."
-      }) }}
 
       {{ govukInput({
         label: {
@@ -46,27 +40,6 @@
         }
       }) }}
 
-      {{ govukRadios({
-        name: "appliesToMh",
-        fieldset: {
-          legend: {
-            text: "Is the flag because the owner of the agreement didn't agree to multiple herds T&C's?",
-            isPageHeading: false,
-            classes: "govuk-fieldset__legend--m"
-          }
-        },
-        items: [
-          {
-            value: "yes",
-            text: "Yes"
-          },
-          {
-            value: "no",
-            text: "No"
-          }
-        ]
-      }) }}
-  
     {{ govukButton({
       text: "Create flag"
     }) }}

--- a/app/views/includes/delete-flag.njk
+++ b/app/views/includes/delete-flag.njk
@@ -11,7 +11,7 @@
             errorList: errors
         }) }}
       {% endif %}
-      <p class="govuk-body govuk-!-margin-bottom-7">Are you sure you want to delete the {{ model.appliesToMh }} flag from agreement {{ model.applicationRefOfFlagToDelete }}?</p>
+      <p class="govuk-body govuk-!-margin-bottom-7">Are you sure you want to delete the flag from agreement {{ model.applicationRefOfFlagToDelete }}?</p>
 
       {{ govukTextarea({
         name: "deletedNote",

--- a/test/integration/narrow/routes/flags.test.js
+++ b/test/integration/narrow/routes/flags.test.js
@@ -79,6 +79,19 @@ describe("Flags tests", () => {
       phaseBannerOk($);
     });
 
+    test("the flags table has no 'Flagged due to multiple herds' column", async () => {
+      const options = {
+        method: "GET",
+        url: "/flags",
+        auth,
+        headers: { cookie: `crumb=${crumb}` },
+      };
+      const res = await server.inject(options);
+
+      expect(res.statusCode).toBe(StatusCodes.OK);
+      expect(res.payload).not.toContain("Flagged due to multiple herds");
+    });
+
     test("returns 200 when user is not an admin", async () => {
       const auth = {
         strategy: "session-auth",
@@ -144,7 +157,29 @@ describe("Flags tests", () => {
       phaseBannerOk($);
     });
 
-    test("the delete form links to the flags endpoint", async () => {
+    test("the create form shows only the reference and note, with no multiple herds question or copy", async () => {
+      const options = {
+        method: "GET",
+        url: "/flags?createFlag=true",
+        auth,
+        headers: { cookie: `crumb=${crumb}` },
+      };
+      const res = await server.inject(options);
+
+      expect(res.statusCode).toBe(StatusCodes.OK);
+      expect(await axe(res.payload)).toHaveNoViolations();
+      const $ = cheerio.load(res.payload);
+
+      expect($('input[name="appRef"]').length).toBe(1);
+      expect($('textarea[name="note"]').length).toBe(1);
+
+      expect($('input[name="appliesToMh"]').length).toBe(0);
+      expect(res.payload).not.toContain("Is the flag because the owner");
+      expect(res.payload).not.toContain("maximum of 2 flags");
+      expect(res.payload).not.toContain("they will not see the multiple herds pages");
+    });
+
+    test("the delete form links to the flags endpoint and does not reference multiple herds", async () => {
       const options = {
         method: "GET",
         url: "/flags?deleteFlag=abc123",
@@ -161,6 +196,11 @@ describe("Flags tests", () => {
       expect($("title").text()).toContain("AHWR Flags");
 
       expect($(".ahwr-update-form").attr("action")).toBe("/flags");
+      expect(res.payload).toContain(
+        "Are you sure you want to delete the flag from agreement IAHW-U6ZE-5R5E?",
+      );
+      expect(res.payload).not.toContain("multiple herds");
+      expect(res.payload).not.toContain("non-MH");
       phaseBannerOk($);
     });
 
@@ -412,7 +452,6 @@ describe("Flags tests", () => {
           crumb,
           appRef: "IAHW-TEST-REF1",
           note: "Test flag",
-          appliesToMh: "yes",
           action: "create",
         },
       };
@@ -420,7 +459,7 @@ describe("Flags tests", () => {
       expect(res.statusCode).toBe(StatusCodes.BAD_REQUEST);
     });
 
-    test("returns the user to the flags page when the flag has been created", async () => {
+    test("returns the user to the flags page when the flag has been created, without an appliesToMh answer", async () => {
       createFlag.mockResolvedValueOnce({ res: { statusCode: 201 } });
       const options = {
         method: "POST",
@@ -431,7 +470,6 @@ describe("Flags tests", () => {
           crumb,
           appRef: "IAHW-TEST-REF1",
           note: "Test flag",
-          appliesToMh: "yes",
           action: "create",
         },
       };
@@ -439,39 +477,10 @@ describe("Flags tests", () => {
 
       expect(res.statusCode).toBe(StatusCodes.OK);
       expect(createFlag).toHaveBeenCalledWith(
-        { appliesToMh: true, note: "Test flag", user: "test admin" },
+        { note: "Test flag", user: "test admin" },
         "IAHW-TEST-REF1",
         expect.any(Object),
       );
-    });
-
-    test("renders errors when the user has not provided the proper appliesToMh value", async () => {
-      const options = {
-        method: "POST",
-        url: "/flags",
-        auth,
-        headers: { cookie: `crumb=${crumb}` },
-        payload: {
-          crumb,
-          appRef: "IAHW-TEST-REF1",
-          note: "Test flag",
-          appliesToMh: "something",
-          action: "create",
-        },
-      };
-      const res = await server.inject(options);
-
-      expect(res.statusCode).toBe(StatusCodes.OK);
-      expect(await axe(res.payload)).toHaveNoViolations();
-
-      const $ = cheerio.load(res.payload);
-      expect($("h1.govuk-heading-l").text()).toContain("Flags");
-      expect($("title").text()).toContain("AHWR Flags");
-      expect($(".govuk-error-summary__list li:first-child a").attr("href")).toBe("#appliesToMh");
-      expect($(".govuk-error-summary__list li:first-child a").text()).toContain(
-        "Select if the flag is because the user declined multiple herds T&C's.",
-      );
-      phaseBannerOk($);
     });
 
     test("renders errors when the user has not provided the proper appRef value", async () => {
@@ -484,7 +493,6 @@ describe("Flags tests", () => {
           crumb,
           appRef: "IAHW-TEST-RE",
           note: "Test flag",
-          appliesToMh: "yes",
           action: "create",
         },
       };
@@ -515,7 +523,6 @@ describe("Flags tests", () => {
           crumb,
           appRef: "IAHW-TEST-REF1",
           note: "",
-          appliesToMh: "yes",
           action: "create",
         },
       };
@@ -534,7 +541,7 @@ describe("Flags tests", () => {
       phaseBannerOk($);
     });
 
-    test("renders an error when the user is trying to create a flag which already exists", async () => {
+    test("renders the reworded error when the agreement already has an active flag", async () => {
       createFlag.mockImplementationOnce(() => {
         let error = new Error("Flag already exists");
         error = {
@@ -556,7 +563,6 @@ describe("Flags tests", () => {
           crumb,
           appRef: "IAHW-TEST-REF1",
           note: "To be flagged",
-          appliesToMh: "yes",
           action: "create",
         },
       };
@@ -572,8 +578,9 @@ describe("Flags tests", () => {
         "#agreement-reference",
       );
       expect($(".govuk-error-summary__list li:first-child a").text()).toContain(
-        'Flag not created - agreement flag with the same "Flag applies to multiple herds T&C\'s" value already exists.',
+        "This agreement already has an active flag.",
       );
+      expect(res.payload).not.toContain("multiple herds");
       phaseBannerOk($);
     });
 
@@ -599,7 +606,6 @@ describe("Flags tests", () => {
           crumb,
           appRef: "IAHW-TEST-REF1",
           note: "To be flagged",
-          appliesToMh: "yes",
           action: "create",
         },
       };
@@ -645,7 +651,6 @@ describe("Flags tests", () => {
           crumb,
           appRef: "IAHW-TEST-REF1",
           note: "To be flagged",
-          appliesToMh: "yes",
           action: "create",
         },
       };

--- a/test/integration/narrow/routes/models/flags-list.test.js
+++ b/test/integration/narrow/routes/models/flags-list.test.js
@@ -27,7 +27,6 @@ describe("createFlagsTableData", () => {
     expect(result).toEqual({
       model: {
         applicationRefOfFlagToDelete: undefined,
-        appliesToMh: "non-MH",
         createFlag: undefined,
         createFlagUrl: `${serviceUri}/flags?createFlag=true`,
         flagIdToDelete: undefined,
@@ -37,7 +36,6 @@ describe("createFlagsTableData", () => {
           { text: "Note" },
           { text: "Created by" },
           { text: "Created at" },
-          { text: "Flagged due to multiple herds" },
           { text: "Action" },
         ],
         rows: [
@@ -47,7 +45,6 @@ describe("createFlagsTableData", () => {
             { text: "Flag this please" },
             { text: "Tom" },
             { text: "Invalid Date" },
-            { text: "No" },
             {
               html: `<a class="govuk-button govuk-button--warning" data-module="govuk-button" href="${serviceUri}/flags?deleteFlag=333c18ef-fb26-4beb-ac87-c483fc886fea">Delete flag</a>`,
             },
@@ -58,7 +55,6 @@ describe("createFlagsTableData", () => {
             { text: "Flag this please" },
             { text: "Ben" },
             { text: "Invalid Date" },
-            { text: "Yes" },
             {
               html: `<a class="govuk-button govuk-button--warning" data-module="govuk-button" href="${serviceUri}/flags?deleteFlag=53dbbc6c-dd14-4d01-be11-ad288cb16b08">Delete flag</a>`,
             },
@@ -79,7 +75,6 @@ describe("createFlagsTableData", () => {
     expect(result).toEqual({
       model: {
         applicationRefOfFlagToDelete: undefined,
-        appliesToMh: "non-MH",
         createFlag: true,
         createFlagUrl: `${serviceUri}/flags?createFlag=true`,
         flagIdToDelete: undefined,
@@ -89,7 +84,6 @@ describe("createFlagsTableData", () => {
           { text: "Note" },
           { text: "Created by" },
           { text: "Created at" },
-          { text: "Flagged due to multiple herds" },
           { text: "Action" },
         ],
         rows: [
@@ -99,7 +93,6 @@ describe("createFlagsTableData", () => {
             { text: "Flag this please" },
             { text: "Tom" },
             { text: "Invalid Date" },
-            { text: "No" },
             {
               html: `<a class="govuk-button govuk-button--warning" data-module="govuk-button" href="${serviceUri}/flags?deleteFlag=333c18ef-fb26-4beb-ac87-c483fc886fea">Delete flag</a>`,
             },
@@ -110,7 +103,6 @@ describe("createFlagsTableData", () => {
             { text: "Flag this please" },
             { text: "Ben" },
             { text: "Invalid Date" },
-            { text: "Yes" },
             {
               html: `<a class="govuk-button govuk-button--warning" data-module="govuk-button" href="${serviceUri}/flags?deleteFlag=53dbbc6c-dd14-4d01-be11-ad288cb16b08">Delete flag</a>`,
             },
@@ -131,7 +123,6 @@ describe("createFlagsTableData", () => {
     expect(result).toEqual({
       model: {
         applicationRefOfFlagToDelete: undefined,
-        appliesToMh: "non-MH",
         createFlag: true,
         createFlagUrl: `${serviceUri}/flags?createFlag=true`,
         flagIdToDelete: undefined,
@@ -141,7 +132,6 @@ describe("createFlagsTableData", () => {
           { text: "Note" },
           { text: "Created by" },
           { text: "Created at" },
-          { text: "Flagged due to multiple herds" },
         ],
         rows: [
           [
@@ -150,7 +140,6 @@ describe("createFlagsTableData", () => {
             { text: "Flag this please" },
             { text: "Tom" },
             { text: "Invalid Date" },
-            { text: "No" },
             { html: "</>" },
           ],
           [
@@ -159,7 +148,6 @@ describe("createFlagsTableData", () => {
             { text: "Flag this please" },
             { text: "Ben" },
             { text: "Invalid Date" },
-            { text: "Yes" },
             { html: "</>" },
           ],
         ],
@@ -193,7 +181,6 @@ describe("createFlagsTableData", () => {
     expect(result).toEqual({
       model: {
         applicationRefOfFlagToDelete: undefined,
-        appliesToMh: "non-MH",
         createFlag: true,
         createFlagUrl: `${serviceUri}/flags?createFlag=true`,
         flagIdToDelete: undefined,
@@ -203,7 +190,6 @@ describe("createFlagsTableData", () => {
           { text: "Note" },
           { text: "Created by" },
           { text: "Created at" },
-          { text: "Flagged due to multiple herds" },
           { text: "Action" },
         ],
         rows: [
@@ -213,7 +199,6 @@ describe("createFlagsTableData", () => {
             { text: "Flag this please" },
             { text: "Tom" },
             { text: "Invalid Date" },
-            { text: "No" },
             { html: "</>" },
           ],
         ],
@@ -232,7 +217,6 @@ describe("createFlagsTableData", () => {
     expect(result).toEqual({
       model: {
         applicationRefOfFlagToDelete: flags[0].applicationReference,
-        appliesToMh: "non-MH",
         createFlag: false,
         createFlagUrl: `${serviceUri}/flags?createFlag=true`,
         flagIdToDelete: flags[0].id,
@@ -242,7 +226,6 @@ describe("createFlagsTableData", () => {
           { text: "Note" },
           { text: "Created by" },
           { text: "Created at" },
-          { text: "Flagged due to multiple herds" },
           { text: "Action" },
         ],
         rows: [
@@ -252,7 +235,6 @@ describe("createFlagsTableData", () => {
             { text: "Flag this please" },
             { text: "Tom" },
             { text: "Invalid Date" },
-            { text: "No" },
             {
               html: `<a class="govuk-button govuk-button--warning" data-module="govuk-button" href="${serviceUri}/flags?deleteFlag=333c18ef-fb26-4beb-ac87-c483fc886fea">Delete flag</a>`,
             },
@@ -263,59 +245,6 @@ describe("createFlagsTableData", () => {
             { text: "Flag this please" },
             { text: "Ben" },
             { text: "Invalid Date" },
-            { text: "Yes" },
-            {
-              html: `<a class="govuk-button govuk-button--warning" data-module="govuk-button" href="${serviceUri}/flags?deleteFlag=53dbbc6c-dd14-4d01-be11-ad288cb16b08">Delete flag</a>`,
-            },
-          ],
-        ],
-      },
-    });
-  });
-
-  it("creates the table data from the getAllFlags API call data when a flagId to delete is passed and it is a flag which applies to multiple herds", async () => {
-    const result = await createFlagsTableData({
-      logger: mockLogger,
-      flagIdToDelete: flags[1].id,
-      createFlag: false,
-      isAdmin: true,
-    });
-
-    expect(result).toEqual({
-      model: {
-        applicationRefOfFlagToDelete: flags[1].applicationReference,
-        appliesToMh: "multiple herds T&C's",
-        createFlag: false,
-        createFlagUrl: `${serviceUri}/flags?createFlag=true`,
-        flagIdToDelete: flags[1].id,
-        header: [
-          { text: "Agreement number" },
-          { text: "SBI" },
-          { text: "Note" },
-          { text: "Created by" },
-          { text: "Created at" },
-          { text: "Flagged due to multiple herds" },
-          { text: "Action" },
-        ],
-        rows: [
-          [
-            { text: "IAHW-U6ZE-5R5E" },
-            { text: "123456789" },
-            { text: "Flag this please" },
-            { text: "Tom" },
-            { text: "Invalid Date" },
-            { text: "No" },
-            {
-              html: `<a class="govuk-button govuk-button--warning" data-module="govuk-button" href="${serviceUri}/flags?deleteFlag=333c18ef-fb26-4beb-ac87-c483fc886fea">Delete flag</a>`,
-            },
-          ],
-          [
-            { text: "IAHW-U6ZE-5R5E" },
-            { text: "123456789" },
-            { text: "Flag this please" },
-            { text: "Ben" },
-            { text: "Invalid Date" },
-            { text: "Yes" },
             {
               html: `<a class="govuk-button govuk-button--warning" data-module="govuk-button" href="${serviceUri}/flags?deleteFlag=53dbbc6c-dd14-4d01-be11-ad288cb16b08">Delete flag</a>`,
             },

--- a/test/unit/api/flags.test.js
+++ b/test/unit/api/flags.test.js
@@ -91,7 +91,7 @@ describe("Flags API", () => {
   });
 
   describe("createFlag", () => {
-    test("uses the provided application reference in the params of the request, and the payload provided as the payload of the API request", async () => {
+    test("posts the agreement reference and payload, always sending appliesToMh false", async () => {
       const wreckResponse = {
         payload: {},
         res: {
@@ -106,7 +106,6 @@ describe("Flags API", () => {
       const payload = {
         user: "Tom",
         note: "I flagged this",
-        appliesToMh: "yes",
       };
 
       await createFlag(payload, applicationReference, mockLogger);
@@ -115,7 +114,7 @@ describe("Flags API", () => {
         `${applicationApiUri}/applications/${applicationReference}/flag`,
         {
           json: true,
-          payload,
+          payload: { ...payload, appliesToMh: false },
           headers: { "x-api-key": apiKeys.backofficeUiApiKey },
         },
       );


### PR DESCRIPTION
## Summary
Removes the now-obsolete "Multiple Herds" question and column from the backoffice flag screens. RPA Ops no longer want this question or its answer, so it has been taken out of the UI. This is a UI-only change confined to the backoffice; the application backend and its stored flag data are left untouched, so no coordinated deployment is required.

## What Changed
- Removed the "Flagged due to multiple herds" column from the Flags tab table.
- Removed the multiple herds question, the "maximum of 2 flags" caption, and the inset warning from the Create flag screen.
- Removed the multiple herds wording from the Delete flag confirmation.
- The backoffice now always sends a "false" multiple herds value to the backend, satisfying the unchanged backend contract.
- Reworded the duplicate-flag error message, which previously referenced the now-removed multiple herds value.
- Updated the affected tests, keeping accessibility (WCAG 2.2 AA) assertions in place.

## Why
RPA Ops have confirmed the multiple herds question is no longer needed and are currently answering "no" to it in all cases as a stopgap. Removing it from the UI tidies up the journey now, while the deferred retirement of the underlying backend behaviour is tracked separately to keep this change single-service and backward compatible.

## Screenshots
<img width="1148" height="1008" alt="Screenshot 2026-06-04 at 13 58 34" src="https://github.com/user-attachments/assets/da0422b0-3db5-416b-8965-ffe2547aae03" />
<img width="1134" height="997" alt="Screenshot 2026-06-04 at 13 58 52" src="https://github.com/user-attachments/assets/95b718dd-5cf6-4902-8baf-f15011e47ae7" />
<img width="1147" height="947" alt="Screenshot 2026-06-04 at 13 59 13" src="https://github.com/user-attachments/assets/56c53304-99fa-4312-aa9f-7df15a8485e8" />
