### PR TITLE
fix: AHWR-1976 backoffice login issues #patch

### DIFF
--- a/app/auth/azure-auth.js
+++ b/app/auth/azure-auth.js
@@ -1,5 +1,5 @@
 import { config } from "../config/index.js";
-import { ConfidentialClientApplication, LogLevel } from "@azure/msal-node";
+import { ConfidentialClientApplication, LogLevel, ResponseMode } from "@azure/msal-node";
 import { getLogger } from "../logging/logger.js";
 
 export const getMsalLoggingSetup = () => {
@@ -38,6 +38,7 @@ export const getAuthenticationUrl = () => {
   const authCodeUrlParameters = {
     prompt: "select_account", // Force the MS account select dialog
     redirectUri: config.auth.redirectUrl,
+    responseMode: ResponseMode.FORM_POST,
   };
 
   return msalApplication.getAuthCodeUrl(authCodeUrlParameters);

--- a/app/routes/authenticate.js
+++ b/app/routes/authenticate.js
@@ -4,15 +4,16 @@ import { setUserDetails } from "../session/index.js";
 import { upperFirstLetter } from "../lib/display-helper.js";
 
 export const authenticateRoute = {
-  method: "GET",
+  method: "POST",
   path: "/authenticate",
   options: {
     auth: { mode: "try" },
+    plugins: { crumb: false },
   },
   handler: async (request, h) => {
     try {
       const [username, roles] = await auth.authenticate(
-        request.query.code,
+        request.payload.code,
         request.server.plugins.auth,
         request.cookieAuth,
       );

--- a/test/integration/narrow/routes/authenticate.test.js
+++ b/test/integration/narrow/routes/authenticate.test.js
@@ -19,24 +19,31 @@ describe("Authentication route tests", () => {
     await server.stop();
   });
 
-  describe("Authenticate GET request", () => {
-    const method = "GET";
-    test("GET /authenticate route redirects to '/'", async () => {
+  describe("Authenticate POST request", () => {
+    const method = "POST";
+    test("POST /authenticate rote redirects to '/claims'", async () => {
       auth.authenticate.mockResolvedValueOnce(["user1", ["role1", "role2"]]);
-      const options = {
-        method,
-        url,
-      };
 
-      const response = await server.inject(options);
+      const response = await server.inject({
+        method: "POST",
+        url,
+        payload: "code=abc123",
+        headers: { "content-type": "application/x-www-form-urlencoded" },
+      });
+
       expect(response.statusCode).toBe(StatusCodes.MOVED_TEMPORARILY);
       expect(response.headers.location).toEqual("/claims");
 
+      expect(auth.authenticate).toHaveBeenCalledWith(
+        "abc123",
+        expect.anything(),
+        expect.anything(),
+      );
       expect(setUserDetails).toHaveBeenCalledWith(expect.anything(), "user", "user1");
       expect(setUserDetails).toHaveBeenCalledWith(expect.anything(), "roles", "Role1, Role2");
     });
 
-    test("GET /authenticate route returns a 500 error due to try catch", async () => {
+    test("POST /authenticate route returns a 500 error due to try catch", async () => {
       auth.authenticate.mockImplementation(() => {
         throw new Error();
       });

--- a/test/integration/narrow/routes/authenticate.test.js
+++ b/test/integration/narrow/routes/authenticate.test.js
@@ -21,7 +21,7 @@ describe("Authentication route tests", () => {
 
   describe("Authenticate POST request", () => {
     const method = "POST";
-    test("POST /authenticate rote redirects to '/claims'", async () => {
+    test("POST /authenticate route redirects to '/claims'", async () => {
       auth.authenticate.mockResolvedValueOnce(["user1", ["role1", "role2"]]);
 
       const response = await server.inject({

--- a/test/unit/auth/azure-auth.test.js
+++ b/test/unit/auth/azure-auth.test.js
@@ -1,8 +1,15 @@
-import { getMsalLoggingSetup } from "../../../app/auth/azure-auth.js";
+import { getMsalLoggingSetup, getAuthenticationUrl, init } from "../../../app/auth/azure-auth.js";
 import { getLogger } from "../../../app/logging/logger.js";
-import { LogLevel } from "@azure/msal-node";
+import { ConfidentialClientApplication, LogLevel, ResponseMode } from "@azure/msal-node";
 
 jest.mock("../../../app/logging/logger.js");
+jest.mock("@azure/msal-node", () => {
+  const actual = jest.requireActual("@azure/msal-node");
+  return {
+    ...actual,
+    ConfidentialClientApplication: jest.fn(),
+  };
+});
 
 const mockLogger = {
   info: jest.fn(),
@@ -34,5 +41,17 @@ describe("Azure auth test", () => {
     getLogger.mockImplementationOnce(() => mockLogger);
     getMsalLoggingSetup().loggerCallback(LogLevel.Info, "test message");
     expect(mockLogger.info).toHaveBeenCalledWith("test message");
+  });
+
+  test("getAuthenticationUrl requests form_post response mode", async () => {
+    const getAuthCodeUrl = jest.fn().mockResolvedValue("https://login.microsoftonline.com/auth");
+    ConfidentialClientApplication.mockImplementation(() => ({ getAuthCodeUrl }));
+    init();
+
+    await getAuthenticationUrl();
+
+    expect(getAuthCodeUrl).toHaveBeenCalledWith(
+      expect.objectContaining({ responseMode: ResponseMode.FORM_POST }),
+    );
   });
 });


### PR DESCRIPTION
Switch to `response_mode=form_post` in the login request and implement a POST version of the `/authenticate` endpoint, which wouldn't be subject to the same WAF constraints.