### PR TITLE
chore: (AHWR-1987) remove stale poultry enabled reference from claim-list test [skip ci]

### DIFF
--- a/app/routes/models/claim-list.test.js
+++ b/app/routes/models/claim-list.test.js
@@ -3,7 +3,6 @@ import { getClaimTableHeader, getClaimTableRows } from "./claim-list.js";
 jest.mock("../../config/index.js", () => ({
   config: {
     serviceUri: "test-uri",
-    poultry: { enabled: false },
   },
 }));
 


### PR DESCRIPTION
chore: (AHWR-1987) remove stale poultry enabled reference from claim-list test [skip ci]