### PR TITLE
fix: (AHWR-1521) render form validation errors in place instead of via the URL #patch

### DIFF
--- a/app/routes/agreement.js
+++ b/app/routes/agreement.js
@@ -88,12 +88,14 @@ const buildAgreementClaimsTable = async (request, applicationReference, page) =>
   const dataURLPrefix = `/agreement/${applicationReference}/`;
   const header = getClaimTableHeader(sortField, dataURLPrefix, showSBI);
 
+  const limit = 30;
+  const offset = 0;
   const { claims, total } = await getClaims(
     "appRef",
     applicationReference,
     undefined,
-    30,
-    0,
+    limit,
+    offset,
     sortField,
     request.logger,
   );
@@ -123,9 +125,9 @@ export const buildAgreement = async (
   const flaggedText = isFlagged ? ` ${FLAG_EMOJI}` : "";
   const isRedacted = application.redacted;
 
-  const { updateEligiblePiiRedactionAction, updateEligiblePiiRedactionForm } = !isRedacted
-    ? getClaimViewStates(request, application.status, null, formFlags)
-    : {};
+  const { updateEligiblePiiRedactionAction, updateEligiblePiiRedactionForm } = isRedacted
+    ? {}
+    : getClaimViewStates(request, application.status, null, formFlags);
 
   const applicationSummaryDetails = buildAgreementSummaryDetails(application, {
     applicationReference,

--- a/app/routes/agreement.js
+++ b/app/routes/agreement.js
@@ -24,6 +24,155 @@ const getBackLink = (page, claimReference, returnPage) => {
     : `/agreements?page=${page}`;
 };
 
+const buildAgreementSummaryDetails = (
+  application,
+  {
+    applicationReference,
+    flaggedText,
+    isFlagged,
+    contactHistoryDetails,
+    updateEligiblePiiRedactionAction,
+  },
+) => {
+  const { organisation } = application;
+  return [
+    {
+      field: "Agreement number",
+      newValue: `${applicationReference}${flaggedText}`,
+      oldValue: null,
+      flagged: isFlagged,
+    },
+    {
+      field: "Agreement date",
+      newValue: formattedDateToUk(application.createdAt),
+      oldValue: null,
+    },
+    {
+      field: "Agreement holder",
+      newValue: organisation.farmerName,
+      oldValue: contactHistoryDetails.farmerName,
+    },
+    {
+      field: "Agreement holder email",
+      newValue: organisation.email,
+      oldValue: contactHistoryDetails.email,
+    },
+    { field: "SBI number", newValue: organisation.sbi, oldValue: null },
+    {
+      field: "Address",
+      newValue: organisation.address,
+      oldValue: contactHistoryDetails.address,
+    },
+    {
+      field: "Business email",
+      newValue: organisation.orgEmail,
+      oldValue: contactHistoryDetails.orgEmail,
+    },
+    {
+      field: "Flagged",
+      newValue: application.flags.length > 0 ? "Yes" : "No",
+      oldValue: null,
+    },
+    {
+      field: "Eligible for automated data redaction",
+      newValue: application.eligiblePiiRedaction ? "Yes" : "No",
+      oldValue: null,
+      change: updateEligiblePiiRedactionAction,
+    },
+  ].filter((row) => row.newValue);
+};
+
+const buildAgreementClaimsTable = async (request, applicationReference, page) => {
+  const sortField = getClaimSearch(request, sessionKeys.claimSearch.sort) ?? undefined;
+  const showSBI = false;
+  const dataURLPrefix = `/agreement/${applicationReference}/`;
+  const header = getClaimTableHeader(sortField, dataURLPrefix, showSBI);
+
+  const { claims, total } = await getClaims(
+    "appRef",
+    applicationReference,
+    undefined,
+    30,
+    0,
+    sortField,
+    request.logger,
+  );
+  const rows = getClaimTableRows(claims, page, "agreement", showSBI);
+
+  return { header, rows, total, claims };
+};
+
+export const buildAgreement = async (
+  request,
+  h,
+  { reference, page, returnPage, backLinkReference, formFlags, errors = [] },
+) => {
+  const applicationReference = reference;
+
+  await generateNewCrumb(request, h);
+  const application = await getApplication(applicationReference, request.logger);
+  const contactHistory = await getContactHistory(applicationReference, request.logger);
+  const contactHistoryDetails = displayContactHistory(contactHistory);
+
+  if (!application) {
+    throw boom.badRequest();
+  }
+
+  const { organisation, status } = application;
+  const isFlagged = application.flags.length > 0;
+  const flaggedText = isFlagged ? ` ${FLAG_EMOJI}` : "";
+  const isRedacted = application.redacted;
+
+  const { updateEligiblePiiRedactionAction, updateEligiblePiiRedactionForm } = !isRedacted
+    ? getClaimViewStates(request, application.status, null, formFlags)
+    : {};
+
+  const applicationSummaryDetails = buildAgreementSummaryDetails(application, {
+    applicationReference,
+    flaggedText,
+    isFlagged,
+    contactHistoryDetails,
+    updateEligiblePiiRedactionAction,
+  });
+
+  const { header, rows, total, claims } = await buildAgreementClaimsTable(
+    request,
+    applicationReference,
+    page,
+  );
+
+  const errorMessages = getErrorMessagesByKey(errors);
+
+  const statusLabel = upperFirstLetter(status.toLowerCase().replaceAll("_", " "));
+  const statusClass = getStyleClassByStatus(status);
+
+  const scheme = getScheme(applicationReference);
+  const claimsBreakdown =
+    scheme === POULTRY_SCHEME ? getSiteBreakdown(claims) : getHerdBreakdown(claims);
+
+  return h.view("agreement", {
+    backLink: getBackLink(page, backLinkReference, returnPage),
+    businessName: organisation.name,
+    applicationSummaryDetails,
+    claimsTotal: total,
+    header,
+    rows,
+    ...claimsBreakdown,
+    updateEligiblePiiRedactionUrl: `/agreement/${applicationReference}/claims?page=${page}&updateEligiblePiiRedaction=true`,
+    updateEligiblePiiRedactionAction,
+    updateEligiblePiiRedactionForm,
+    eligiblePiiRedaction: application.eligiblePiiRedaction,
+    reference: application.reference,
+    page,
+    errorMessages,
+    errors,
+    applicationStatus: {
+      statusLabel,
+      statusClass,
+    },
+  });
+};
+
 export const agreementRoutes = [
   {
     method: "GET",
@@ -41,133 +190,17 @@ export const agreementRoutes = [
           page: joi.number().greater(0).default(1),
           returnPage: joi.string(),
           updateEligiblePiiRedaction: joi.bool().default(false),
-          errors: joi.string().allow(null),
+          errors: joi.any().strip(),
         }),
       },
       handler: async (request, h) => {
-        const { page, reference, returnPage } = request.query;
-        const { reference: applicationReference } = request.params;
-
-        await generateNewCrumb(request, h);
-        const application = await getApplication(applicationReference, request.logger);
-        const contactHistory = await getContactHistory(applicationReference, request.logger);
-        const contactHistoryDetails = displayContactHistory(contactHistory);
-
-        if (!application) {
-          throw boom.badRequest();
-        }
-
-        const { organisation, status } = application;
-        const isFlagged = application.flags.length > 0;
-        const flaggedText = isFlagged ? ` ${FLAG_EMOJI}` : "";
-        const isRedacted = application.redacted;
-
-        const { updateEligiblePiiRedactionAction, updateEligiblePiiRedactionForm } = !isRedacted
-          ? getClaimViewStates(request, application.status, null)
-          : {};
-
-        const summaryDetails = [
-          {
-            field: "Agreement number",
-            newValue: `${applicationReference}${flaggedText}`,
-            oldValue: null,
-            flagged: isFlagged,
-          },
-          {
-            field: "Agreement date",
-            newValue: formattedDateToUk(application.createdAt),
-            oldValue: null,
-          },
-          {
-            field: "Agreement holder",
-            newValue: organisation.farmerName,
-            oldValue: contactHistoryDetails.farmerName,
-          },
-          {
-            field: "Agreement holder email",
-            newValue: organisation.email,
-            oldValue: contactHistoryDetails.email,
-          },
-          { field: "SBI number", newValue: organisation.sbi, oldValue: null },
-          {
-            field: "Address",
-            newValue: organisation.address,
-            oldValue: contactHistoryDetails.address,
-          },
-          {
-            field: "Business email",
-            newValue: organisation.orgEmail,
-            oldValue: contactHistoryDetails.orgEmail,
-          },
-          {
-            field: "Flagged",
-            newValue: application.flags.length > 0 ? "Yes" : "No",
-            oldValue: null,
-          },
-          {
-            field: "Eligible for automated data redaction",
-            newValue: application.eligiblePiiRedaction ? "Yes" : "No",
-            oldValue: null,
-            change: updateEligiblePiiRedactionAction,
-          },
-        ];
-
-        const applicationSummaryDetails = summaryDetails.filter((row) => row.newValue);
-
-        const sortField = getClaimSearch(request, sessionKeys.claimSearch.sort) ?? undefined;
-        const showSBI = false;
-        const dataURLPrefix = `/agreement/${applicationReference}/`;
-        const header = getClaimTableHeader(sortField, dataURLPrefix, showSBI);
-
-        const searchText = applicationReference;
-        const searchType = "appRef";
-        const filter = undefined;
-        const limit = 30;
-        const offset = 0;
-        const { claims, total } = await getClaims(
-          searchType,
-          searchText,
-          filter,
-          limit,
-          offset,
-          sortField,
-          request.logger,
-        );
-        const claimReturnPage = "agreement";
-        const rows = getClaimTableRows(claims, page, claimReturnPage, showSBI);
-
-        const errors = request.query.errors
-          ? JSON.parse(Buffer.from(request.query.errors, "base64").toString("utf8"))
-          : [];
-        const errorMessages = getErrorMessagesByKey(errors);
-
-        const statusLabel = upperFirstLetter(status.toLowerCase().replaceAll("_", " "));
-        const statusClass = getStyleClassByStatus(status);
-
-        const scheme = getScheme(applicationReference);
-        const claimsBreakdown =
-          scheme === POULTRY_SCHEME ? getSiteBreakdown(claims) : getHerdBreakdown(claims);
-
-        return h.view("agreement", {
-          backLink: getBackLink(page, reference, returnPage),
-          businessName: organisation.name,
-          applicationSummaryDetails,
-          claimsTotal: total,
-          header,
-          rows,
-          ...claimsBreakdown,
-          updateEligiblePiiRedactionUrl: `/agreement/${applicationReference}/claims?page=${page}&updateEligiblePiiRedaction=true`,
-          updateEligiblePiiRedactionAction,
-          updateEligiblePiiRedactionForm,
-          eligiblePiiRedaction: application.eligiblePiiRedaction,
-          reference: application.reference,
-          page,
-          errorMessages,
-          errors,
-          applicationStatus: {
-            statusLabel,
-            statusClass,
-          },
+        return buildAgreement(request, h, {
+          reference: request.params.reference,
+          page: request.query.page,
+          returnPage: request.query.returnPage,
+          backLinkReference: request.query.reference,
+          formFlags: request.query,
+          errors: [],
         });
       },
     },

--- a/app/routes/agreements-eligible-pii-redaction.js
+++ b/app/routes/agreements-eligible-pii-redaction.js
@@ -2,7 +2,10 @@ import joi from "joi";
 import { generateNewCrumb } from "./utils/crumb-cache.js";
 import { permissions } from "../auth/permissions.js";
 import { updateEligiblePiiRedaction } from "../api/applications.js";
-import { encodeErrorsForUI } from "./utils/encode-errors-for-ui.js";
+import { formatErrorsForUI } from "./utils/format-errors-for-ui.js";
+import { getFormFlags } from "./utils/get-form-flags.js";
+import { buildViewAgreement } from "./view-agreement.js";
+import { buildAgreement } from "./agreement.js";
 
 const { administrator } = permissions;
 
@@ -31,20 +34,18 @@ export const updateEligiblePiiRedactionRoute = {
 
         request.logger.error({ error });
 
-        const panelID = "#update-eligible-pii-redaction";
-
-        const errors = encodeErrorsForUI(error.details, panelID);
-        const query = new URLSearchParams({
-          page,
-          updateEligiblePiiRedaction: "true",
-          errors,
-        });
+        const errors = formatErrorsForUI(error.details, "#update-eligible-pii-redaction");
+        const formFlags = getFormFlags("updateEligiblePiiRedaction");
 
         if (reference.startsWith("AHWR")) {
-          return h.redirect(`/view-agreement/${reference}?${query.toString()}`).takeover();
+          return (
+            await buildViewAgreement(request, h, { reference, page, formFlags, errors })
+          ).takeover();
         }
 
-        return h.redirect(`/agreement/${reference}/claims?${query.toString()}`).takeover();
+        return (
+          await buildAgreement(request, h, { reference, page, formFlags, errors })
+        ).takeover();
       },
     },
     handler: async (request, h) => {

--- a/app/routes/claim/build-update-claim-route.js
+++ b/app/routes/claim/build-update-claim-route.js
@@ -1,23 +1,24 @@
-import { encodeErrorsForUI } from "../utils/encode-errors-for-ui.js";
+import { formatErrorsForUI } from "../utils/format-errors-for-ui.js";
+import { getFormFlags } from "../utils/get-form-flags.js";
+import { buildViewClaim } from "../view-claim.js";
 import { generateNewCrumb } from "../utils/crumb-cache.js";
 import { updateClaimStatus } from "../../api/claims.js";
 import { preSubmissionHandler } from "../utils/pre-submission-handler.js";
 import Joi from "joi";
 
-export const updateClaimFailAction = (request, h, error, errorHref, searchParam) => {
+export const updateClaimFailAction = async (request, h, error, errorHref, searchParam) => {
   const { page, reference, returnPage } = request.payload;
   request.logger.error({ error, reference });
 
-  const errors = encodeErrorsForUI(error.details, errorHref);
-
-  const query = new URLSearchParams({
-    page,
-    [searchParam]: "true",
-    errors,
-  });
-  query.append("returnPage", returnPage);
-
-  return h.redirect(`/view-claim/${reference}?${query.toString()}`).takeover();
+  return (
+    await buildViewClaim(request, h, {
+      reference,
+      page,
+      returnPage,
+      formFlags: getFormFlags(searchParam),
+      errors: formatErrorsForUI(error.details, errorHref),
+    })
+  ).takeover();
 };
 
 export const updateClaimHandler = async (request, h, status) => {

--- a/app/routes/claims-data.js
+++ b/app/routes/claims-data.js
@@ -3,7 +3,10 @@ import { generateNewCrumb } from "./utils/crumb-cache.js";
 import { permissions } from "../auth/permissions.js";
 import { updateClaimData } from "../api/claims.js";
 import { updateApplicationData } from "../api/applications.js";
-import { encodeErrorsForUI } from "./utils/encode-errors-for-ui.js";
+import { formatErrorsForUI } from "./utils/format-errors-for-ui.js";
+import { getFormFlags } from "./utils/get-form-flags.js";
+import { buildViewClaim } from "./view-claim.js";
+import { buildViewAgreement } from "./view-agreement.js";
 import { PIGS_AND_PAYMENTS_RELEASE_DATE } from "../constants/index.js";
 
 const { administrator } = permissions;
@@ -28,26 +31,21 @@ const affectsPaymentRate = (originalDateString, newDate) => {
   );
 };
 
-const encodeErrAndRedirectBackToView = (request, h, error) => {
-  const { claimOrAgreement, form, page, reference, returnPage } = request.payload;
+const renderErrAtView = async (request, h, error) => {
+  const { claimOrAgreement, form: formName, page, reference, returnPage } = request.payload;
 
-  request.logger.error({ error, form });
+  request.logger.error({ error, form: formName });
 
-  const panelID = panelIdGivenFormName(form);
-
-  const errors = encodeErrorsForUI(error.details, panelID);
-
-  const query = new URLSearchParams({
-    page,
-    [form]: "true",
-    errors,
-  });
+  const errors = formatErrorsForUI(error.details, panelIdGivenFormName(formName));
+  const formFlags = getFormFlags(formName);
 
   if (claimOrAgreement === "claim") {
-    query.append("returnPage", returnPage);
+    return (
+      await buildViewClaim(request, h, { reference, page, returnPage, formFlags, errors })
+    ).takeover();
   }
 
-  return h.redirect(`/view-${claimOrAgreement}/${reference}?${query.toString()}`).takeover();
+  return (await buildViewAgreement(request, h, { reference, page, formFlags, errors })).takeover();
 };
 
 export const claimsDataRoutes = [
@@ -132,7 +130,7 @@ export const claimsDataRoutes = [
           })
           .required(),
         failAction: async (request, h, error) => {
-          return encodeErrAndRedirectBackToView(request, h, error);
+          return renderErrAtView(request, h, error);
         },
       },
       handler: async (request, h) => {
@@ -176,7 +174,7 @@ export const claimsDataRoutes = [
               },
             ],
           };
-          return encodeErrAndRedirectBackToView(request, h, err);
+          return renderErrAtView(request, h, err);
         }
 
         await generateNewCrumb(request, h);

--- a/app/routes/utils/encode-errors-for-ui.js
+++ b/app/routes/utils/encode-errors-for-ui.js
@@ -1,9 +1,0 @@
-export const encodeErrorsForUI = (joiErrors, href) => {
-  const errors = joiErrors.map((error) => ({
-    text: error.message,
-    href,
-    key: error.context.key,
-  }));
-
-  return Buffer.from(JSON.stringify(errors)).toString("base64");
-};

--- a/app/routes/utils/format-errors-for-ui.js
+++ b/app/routes/utils/format-errors-for-ui.js
@@ -1,0 +1,6 @@
+export const formatErrorsForUI = (joiErrors, href) =>
+  joiErrors.map((error) => ({
+    text: error.message,
+    href,
+    key: error.context.key,
+  }));

--- a/app/routes/utils/get-claim-view-states.js
+++ b/app/routes/utils/get-claim-view-states.js
@@ -150,7 +150,26 @@ const getAdminActionsAvailable = ({
   };
 };
 
-export const getClaimViewStates = (request, status, currentStatusEvent) => {
+export const DEFAULT_FORM_FLAGS = {
+  withdraw: false,
+  moveToInCheck: false,
+  recommendToPay: false,
+  recommendToReject: false,
+  approve: false,
+  reject: false,
+  updateStatus: false,
+  updateVetsName: false,
+  updateDateOfVisit: false,
+  updateVetRCVSNumber: false,
+  updateEligiblePiiRedaction: false,
+};
+
+export const getClaimViewStates = (
+  request,
+  status,
+  currentStatusEvent,
+  formFlags = request.query,
+) => {
   const {
     withdraw,
     moveToInCheck,
@@ -163,7 +182,7 @@ export const getClaimViewStates = (request, status, currentStatusEvent) => {
     updateDateOfVisit,
     updateVetRCVSNumber,
     updateEligiblePiiRedaction,
-  } = request.query;
+  } = formFlags;
   const { name } = request.auth.credentials.account;
 
   const { isAdministrator, isRecommender, isAuthoriser, isSuperAdmin } = mapAuth(request);

--- a/app/routes/utils/get-form-flags.js
+++ b/app/routes/utils/get-form-flags.js
@@ -1,0 +1,3 @@
+import { DEFAULT_FORM_FLAGS } from "./get-claim-view-states.js";
+
+export const getFormFlags = (formFlagKey) => ({ ...DEFAULT_FORM_FLAGS, [formFlagKey]: true });

--- a/app/routes/view-agreement.js
+++ b/app/routes/view-agreement.js
@@ -14,7 +14,103 @@ import { getApplicationClaimDetails } from "./models/application-claim.js";
 
 const { administrator, processor, user, recommender, authoriser } = permissions;
 
+const buildAgreementChangeActions = (viewStates, reference, page) => {
+  const getAction = (query, visuallyHiddenText, id) => ({
+    items: [
+      {
+        href: `/view-agreement/${reference}?${query}=true&page=${page}#${id}`,
+        text: "Change",
+        visuallyHiddenText,
+      },
+    ],
+  });
+
+  return {
+    dateOfVisitActions: viewStates.updateDateOfVisitAction
+      ? getAction("updateDateOfVisit", "date of review", "update-date-of-visit")
+      : null,
+    vetsNameActions: viewStates.updateVetsNameAction
+      ? getAction("updateVetsName", "vet's name", "update-vets-name")
+      : null,
+    vetRCVSNumberActions: viewStates.updateVetRCVSNumberAction
+      ? getAction("updateVetRCVSNumber", "RCVS number", "update-vet-rcvs-number")
+      : null,
+    eligiblePiiRedactionActions: viewStates.updateEligiblePiiRedactionAction
+      ? getAction(
+          "updateEligiblePiiRedaction",
+          "eligible for automated data redaction",
+          "update-eligible-pii-redaction",
+        )
+      : null,
+  };
+};
+
 // Viewing OW agreement
+export const buildViewAgreement = async (
+  request,
+  h,
+  { reference, page, formFlags, errors = [] },
+) => {
+  const application = await getApplication(reference, request.logger);
+  const { status } = application;
+  const { historyRecords } = await getOldWorldApplicationHistory(
+    application.reference,
+    request.logger,
+  );
+  const currentStatusEvent = getCurrentStatusEvent(application, historyRecords);
+
+  const statusLabel = upperFirstLetter(status.toLowerCase().replaceAll("_", " "));
+
+  const statusClass = getStyleClassByStatus(status);
+
+  const viewStates = !application.redacted
+    ? getClaimViewStates(request, status, currentStatusEvent, formFlags)
+    : {};
+  const { updateVetsNameForm, updateVetRCVSNumberForm, updateDateOfVisitForm } = viewStates;
+  const { updateEligiblePiiRedactionAction, updateEligiblePiiRedactionForm } = viewStates;
+
+  const { dateOfVisitActions, vetsNameActions, vetRCVSNumberActions, eligiblePiiRedactionActions } =
+    buildAgreementChangeActions(viewStates, application.reference, page);
+
+  const contactHistory = await getContactHistory(reference, request.logger);
+  const contactHistoryDetails = displayContactHistory(contactHistory);
+  const { organisation } = application;
+  const organisationDetails = getOrganisationDetails(organisation, contactHistoryDetails);
+  const applicationDetails = getApplicationDetails(application, eligiblePiiRedactionActions);
+  const historyDetails = getHistoryDetails(historyRecords);
+  const applicationClaimDetails = getApplicationClaimDetails(
+    application,
+    dateOfVisitActions,
+    vetsNameActions,
+    vetRCVSNumberActions,
+  );
+  const errorMessages = getErrorMessagesByKey(errors);
+
+  return h.view("view-agreement", {
+    page,
+    reference: application.reference,
+    claimOrAgreement: "agreement",
+    statusLabel,
+    statusClass,
+    organisationName: organisation.name,
+    vetVisit: application.vetVisit,
+    claimed: application.claimed,
+    payment: application.payment,
+    organisationDetails,
+    applicationDetails,
+    historyDetails,
+    applicationClaimDetails,
+    updateDateOfVisitForm,
+    updateVetsNameForm,
+    updateVetRCVSNumberForm,
+    updateEligiblePiiRedactionAction,
+    updateEligiblePiiRedactionForm,
+    eligiblePiiRedaction: application.eligiblePiiRedaction,
+    errorMessages,
+    errors,
+  });
+};
+
 export const viewAgreementRoute = {
   method: "get",
   path: "/view-agreement/{reference}",
@@ -26,7 +122,7 @@ export const viewAgreementRoute = {
       }),
       query: joi.object({
         page: joi.number().greater(0).default(1),
-        errors: joi.string().allow(null),
+        errors: joi.any().strip(),
         updateVetsName: joi.bool().default(false),
         updateDateOfVisit: joi.bool().default(false),
         updateVetRCVSNumber: joi.bool().default(false),
@@ -34,98 +130,11 @@ export const viewAgreementRoute = {
       }),
     },
     handler: async (request, h) => {
-      const { page } = request.query;
-      const application = await getApplication(request.params.reference, request.logger);
-      const { status } = application;
-      const { historyRecords } = await getOldWorldApplicationHistory(
-        application.reference,
-        request.logger,
-      );
-      const currentStatusEvent = getCurrentStatusEvent(application, historyRecords);
-
-      const statusLabel = upperFirstLetter(status.toLowerCase().replaceAll("_", " "));
-
-      const statusClass = getStyleClassByStatus(status);
-
-      const isRedacted = application.redacted;
-
-      const {
-        updateVetsNameAction,
-        updateVetsNameForm,
-        updateVetRCVSNumberAction,
-        updateVetRCVSNumberForm,
-        updateDateOfVisitAction,
-        updateDateOfVisitForm,
-        updateEligiblePiiRedactionAction,
-        updateEligiblePiiRedactionForm,
-      } = !isRedacted ? getClaimViewStates(request, status, currentStatusEvent) : {};
-
-      const errors = request.query.errors
-        ? JSON.parse(Buffer.from(request.query.errors, "base64").toString("utf8"))
-        : [];
-
-      const getAction = (query, visuallyHiddenText, id) => ({
-        items: [
-          {
-            href: `/view-agreement/${application.reference}?${query}=true&page=${page}#${id}`,
-            text: "Change",
-            visuallyHiddenText,
-          },
-        ],
-      });
-      const dateOfVisitActions = updateDateOfVisitAction
-        ? getAction("updateDateOfVisit", "date of review", "update-date-of-visit")
-        : null;
-      const vetsNameActions = updateVetsNameAction
-        ? getAction("updateVetsName", "vet's name", "update-vets-name")
-        : null;
-      const vetRCVSNumberActions = updateVetRCVSNumberAction
-        ? getAction("updateVetRCVSNumber", "RCVS number", "update-vet-rcvs-number")
-        : null;
-      const eligiblePiiRedactionActions = updateEligiblePiiRedactionAction
-        ? getAction(
-            "updateEligiblePiiRedaction",
-            "eligible for automated data redaction",
-            "update-eligible-pii-redaction",
-          )
-        : null;
-
-      const contactHistory = await getContactHistory(request.params.reference, request.logger);
-      const contactHistoryDetails = displayContactHistory(contactHistory);
-      const { organisation } = application;
-      const organisationDetails = getOrganisationDetails(organisation, contactHistoryDetails);
-      const applicationDetails = getApplicationDetails(application, eligiblePiiRedactionActions);
-      const historyDetails = getHistoryDetails(historyRecords);
-      const applicationClaimDetails = getApplicationClaimDetails(
-        application,
-        dateOfVisitActions,
-        vetsNameActions,
-        vetRCVSNumberActions,
-      );
-      const errorMessages = getErrorMessagesByKey(errors);
-
-      return h.view("view-agreement", {
-        page,
-        reference: application.reference,
-        claimOrAgreement: "agreement",
-        statusLabel,
-        statusClass,
-        organisationName: organisation.name,
-        vetVisit: application.vetVisit,
-        claimed: application.claimed,
-        payment: application.payment,
-        organisationDetails,
-        applicationDetails,
-        historyDetails,
-        applicationClaimDetails,
-        updateDateOfVisitForm,
-        updateVetsNameForm,
-        updateVetRCVSNumberForm,
-        updateEligiblePiiRedactionAction,
-        updateEligiblePiiRedactionForm,
-        eligiblePiiRedaction: application.eligiblePiiRedaction,
-        errorMessages,
-        errors,
+      return buildViewAgreement(request, h, {
+        reference: request.params.reference,
+        page: request.query.page,
+        formFlags: request.query,
+        errors: [],
       });
     },
   },

--- a/app/routes/view-agreement.js
+++ b/app/routes/view-agreement.js
@@ -63,9 +63,9 @@ export const buildViewAgreement = async (
 
   const statusClass = getStyleClassByStatus(status);
 
-  const viewStates = !application.redacted
-    ? getClaimViewStates(request, status, currentStatusEvent, formFlags)
-    : {};
+  const viewStates = application.redacted
+    ? {}
+    : getClaimViewStates(request, status, currentStatusEvent, formFlags);
   const { updateVetsNameForm, updateVetRCVSNumberForm, updateDateOfVisitForm } = viewStates;
   const { updateEligiblePiiRedactionAction, updateEligiblePiiRedactionForm } = viewStates;
 

--- a/app/routes/view-claim.js
+++ b/app/routes/view-claim.js
@@ -58,12 +58,14 @@ const prepareClaimSummaryRows = (scheme, claim, organisation, { page, returnPage
 };
 
 const loadClaimsBreakdown = async (scheme, applicationReference, logger) => {
+  const limit = 30;
+  const offset = 0;
   const { claims } = await getClaims(
     "appRef",
     applicationReference,
     undefined,
-    30,
-    0,
+    limit,
+    offset,
     undefined,
     logger,
   );

--- a/app/routes/view-claim.js
+++ b/app/routes/view-claim.js
@@ -1,4 +1,3 @@
-import { Buffer } from "node:buffer";
 import joi from "joi";
 import { getClaim, getClaimHistory, getClaims } from "../api/claims.js";
 import { getHistoryDetails } from "./models/application-history.js";
@@ -24,6 +23,110 @@ const backLink = (applicationReference, returnPage, page) => {
     : `/claims?page=${page}`;
 };
 
+const buildClaimApplicationSummary = (application, applicationReference) => {
+  const { organisation } = application;
+  return [
+    buildKeyValueJson("Agreement number", applicationReference),
+    buildKeyValueJson("Agreement date", formattedDateToUk(application.createdAt)),
+    buildKeyValueJson("Agreement holder", organisation.farmerName),
+    buildKeyValueJson("Agreement holder email", organisation.email),
+    buildKeyValueJson("SBI number", organisation.sbi),
+    buildKeyValueJson("Address", organisation.address.split(",").join(", ")),
+    buildKeyValueJson("Business email", organisation.orgEmail),
+    buildKeyValueJson("Flagged", application.flags.length > 0 ? "Yes" : "No"),
+  ];
+};
+
+const prepareClaimSummaryRows = (scheme, claim, organisation, { page, returnPage }, viewStates) => {
+  const { data, reference: claimReference, type, status: claimStatus, createdAt, herd } = claim;
+  const rowPreparation =
+    scheme === POULTRY_SCHEME ? preparePoultryClaimDisplayRows : prepareLivestockClaimDisplayRows;
+
+  const rows = rowPreparation(
+    data,
+    { type, claimStatus, createdAt, organisation, herd },
+    { claimReference, page, returnPage },
+    {
+      updateStatusAction: viewStates.updateStatusAction,
+      updateDateOfVisitAction: viewStates.updateDateOfVisitAction,
+      updateVetsNameAction: viewStates.updateVetsNameAction,
+      updateVetRCVSNumberAction: viewStates.updateVetRCVSNumberAction,
+    },
+  );
+
+  return rows.filter((row) => row?.value?.html);
+};
+
+const loadClaimsBreakdown = async (scheme, applicationReference, logger) => {
+  const { claims } = await getClaims(
+    "appRef",
+    applicationReference,
+    undefined,
+    30,
+    0,
+    undefined,
+    logger,
+  );
+  return scheme === POULTRY_SCHEME ? getSiteBreakdown(claims) : getHerdBreakdown(claims);
+};
+
+export const buildViewClaim = async (
+  request,
+  h,
+  { reference, page, returnPage, formFlags, errors = [] },
+) => {
+  const claim = await getClaim(reference, request.logger);
+  const { data, reference: claimReference, applicationReference, status: claimStatus } = claim;
+
+  // TODO - look at removing setBindings here
+  request.logger.setBindings({ applicationReference, claimReference });
+
+  const application = await getApplication(applicationReference, request.logger);
+  const { organisation } = application;
+
+  // TODO - look at removing setBindings here
+  request.logger.setBindings({ sbi: organisation.sbi });
+
+  const { historyRecords } = await getClaimHistory(claimReference, request.logger);
+  const currentStatusEvent = getCurrentStatusEvent(claim, historyRecords);
+
+  const viewStates = application.redacted
+    ? {}
+    : getClaimViewStates(request, claim.status, currentStatusEvent, formFlags);
+
+  const scheme = getScheme(applicationReference);
+
+  return h.view("view-claim", {
+    page,
+    backLink: backLink(applicationReference, returnPage, page),
+    returnPage,
+    isFlagged: application.flags.length > 0,
+    reference: claimReference,
+    applicationReference,
+    claimOrAgreement: "claim",
+    dateOfVisit: data?.dateOfVisit,
+    title: upperFirstLetter(organisation.name),
+    claimSummaryDetails: prepareClaimSummaryRows(
+      scheme,
+      claim,
+      organisation,
+      { page, returnPage },
+      viewStates,
+    ),
+    status: {
+      normalType: upperFirstLetter(claim.status.replaceAll("_", " ").toLowerCase()),
+      tagClass: getStyleClassByStatus(claim.status.replaceAll("_", " ")),
+    },
+    applicationSummaryDetails: buildClaimApplicationSummary(application, applicationReference),
+    historyDetails: getHistoryDetails(historyRecords),
+    statusOptions: getStatusUpdateOptions(claimStatus),
+    errorMessages: getErrorMessagesByKey(errors),
+    errors,
+    ...viewStates,
+    ...(await loadClaimsBreakdown(scheme, applicationReference, request.logger)),
+  });
+};
+
 export const viewClaimRoute = {
   method: "get",
   path: "/view-claim/{reference}",
@@ -36,7 +139,7 @@ export const viewClaimRoute = {
       query: joi.object({
         page: joi.string().default(1).allow(null),
         returnPage: joi.string().optional().allow("").valid("agreement", "claims"),
-        errors: joi.string().allow(null),
+        errors: joi.any().strip(),
         moveToInCheck: joi.bool().default(false),
         recommendToPay: joi.bool().default(false),
         recommendToReject: joi.bool().default(false),
@@ -50,146 +153,12 @@ export const viewClaimRoute = {
     },
     handler: async (request, h) => {
       const { page, returnPage } = request.query;
-      const claim = await getClaim(request.params.reference, request.logger);
-
-      const {
-        data,
-        reference: claimReference,
-        type,
-        applicationReference,
-        status: claimStatus,
-        createdAt,
-        herd,
-      } = claim;
-
-      // TODO - look at removing setBindings here
-      request.logger.setBindings({ applicationReference, claimReference });
-
-      const application = await getApplication(applicationReference, request.logger);
-
-      const { organisation } = application;
-
-      // TODO - look at removing setBindings here
-      request.logger.setBindings({ sbi: organisation.sbi });
-
-      const isFlagged = application.flags.length > 0;
-      const flaggedText = isFlagged ? "Yes" : "No";
-
-      const isRedacted = application.redacted;
-
-      const applicationSummaryDetails = [
-        buildKeyValueJson("Agreement number", applicationReference),
-        buildKeyValueJson("Agreement date", formattedDateToUk(application.createdAt)),
-        buildKeyValueJson("Agreement holder", organisation.farmerName),
-        buildKeyValueJson("Agreement holder email", organisation.email),
-        buildKeyValueJson("SBI number", organisation.sbi),
-        buildKeyValueJson("Address", organisation.address.split(",").join(", ")),
-        buildKeyValueJson("Business email", organisation.orgEmail),
-        buildKeyValueJson("Flagged", flaggedText),
-      ];
-
-      const errors = request.query.errors
-        ? JSON.parse(Buffer.from(request.query.errors, "base64").toString("utf8"))
-        : [];
-
-      const { historyRecords } = await getClaimHistory(claimReference, request.logger);
-      const historyDetails = getHistoryDetails(historyRecords);
-      const currentStatusEvent = getCurrentStatusEvent(claim, historyRecords);
-
-      const {
-        moveToInCheckAction,
-        moveToInCheckForm,
-        recommendAction,
-        recommendToPayForm,
-        recommendToRejectForm,
-        authoriseAction,
-        authoriseForm,
-        rejectAction,
-        rejectForm,
-        updateStatusAction,
-        updateStatusForm,
-        updateVetsNameAction,
-        updateVetsNameForm,
-        updateVetRCVSNumberAction,
-        updateVetRCVSNumberForm,
-        updateDateOfVisitAction,
-        updateDateOfVisitForm,
-      } = isRedacted ? {} : getClaimViewStates(request, claim.status, currentStatusEvent);
-
-      const statusOptions = getStatusUpdateOptions(claimStatus);
-
-      const scheme = getScheme(applicationReference);
-
-      const rowPreparation =
-        scheme === POULTRY_SCHEME
-          ? preparePoultryClaimDisplayRows
-          : prepareLivestockClaimDisplayRows;
-
-      const rows = rowPreparation(
-        data,
-        { type, claimStatus, createdAt, organisation, herd },
-        { claimReference, page, returnPage },
-        {
-          updateStatusAction,
-          updateDateOfVisitAction,
-          updateVetsNameAction,
-          updateVetRCVSNumberAction,
-        },
-      );
-
-      const rowsWithData = rows.filter((row) => row?.value?.html);
-      const errorMessages = getErrorMessagesByKey(errors);
-      const searchText = applicationReference;
-      const searchType = "appRef";
-      const limit = 30;
-      const offset = 0;
-      const { claims } = await getClaims(
-        searchType,
-        searchText,
-        undefined,
-        limit,
-        offset,
-        undefined,
-        request.logger,
-      );
-
-      const claimsBreakdown =
-        scheme === POULTRY_SCHEME ? getSiteBreakdown(claims) : getHerdBreakdown(claims);
-
-      return h.view("view-claim", {
+      return buildViewClaim(request, h, {
+        reference: request.params.reference,
         page,
-        backLink: backLink(applicationReference, returnPage, page),
         returnPage,
-        isFlagged,
-        reference: claimReference,
-        applicationReference,
-        claimOrAgreement: "claim",
-        dateOfVisit: data?.dateOfVisit,
-        title: upperFirstLetter(organisation.name),
-        claimSummaryDetails: rowsWithData,
-        status: {
-          normalType: upperFirstLetter(claim.status.replaceAll("_", " ").toLowerCase()),
-          tagClass: getStyleClassByStatus(claim.status.replaceAll("_", " ")),
-        },
-        applicationSummaryDetails,
-        historyDetails,
-        moveToInCheckAction,
-        moveToInCheckForm,
-        recommendAction,
-        recommendToPayForm,
-        recommendToRejectForm,
-        rejectAction,
-        rejectForm,
-        authoriseAction,
-        authoriseForm,
-        updateStatusForm,
-        updateVetsNameForm,
-        updateVetRCVSNumberForm,
-        updateDateOfVisitForm,
-        statusOptions,
-        errorMessages,
-        errors,
-        ...claimsBreakdown,
+        formFlags: request.query,
+        errors: [],
       });
     },
   },

--- a/test/integration/narrow/routes/agreement.test.js
+++ b/test/integration/narrow/routes/agreement.test.js
@@ -102,7 +102,7 @@ describe("Claims test", () => {
       const $ = cheerio.load(res.payload);
 
       expect(res.statusCode).toBe(StatusCodes.OK);
-      expect($(".govuk-error-summary").length).toBe(0);
+      expect($(".govuk-error-summary")).toHaveLength(0);
       expect(res.payload).not.toContain("Injected link");
     });
 

--- a/test/integration/narrow/routes/agreement.test.js
+++ b/test/integration/narrow/routes/agreement.test.js
@@ -86,6 +86,26 @@ describe("Claims test", () => {
       expect(res.statusCode).toBe(400);
     });
 
+    test("ignores an errors query parameter added manually to the URL", async () => {
+      getApplication.mockReturnValue(applicationsData.applications[0]);
+      const injected = Buffer.from(
+        JSON.stringify([{ text: "Injected link", href: "#x", key: "y" }]),
+      ).toString("base64");
+
+      const options = {
+        method: "GET",
+        url: `${url}?page=1&errors=${injected}`,
+        auth,
+      };
+
+      const res = await server.inject(options);
+      const $ = cheerio.load(res.payload);
+
+      expect(res.statusCode).toBe(StatusCodes.OK);
+      expect($(".govuk-error-summary").length).toBe(0);
+      expect(res.payload).not.toContain("Injected link");
+    });
+
     test("returns 200", async () => {
       const options = {
         method: "GET",

--- a/test/integration/narrow/routes/agreements-eligible-pii-redaction.test.js
+++ b/test/integration/narrow/routes/agreements-eligible-pii-redaction.test.js
@@ -1,32 +1,32 @@
+import * as cheerio from "cheerio";
+import { axe } from "../../../helpers/axe-helper.js";
 import { getCrumbs } from "../../../utils/get-crumbs.js";
 import { permissions } from "../../../../app/auth/permissions.js";
 import { getClaims } from "../../../../app/api/claims.js";
+import {
+  getApplication,
+  getOldWorldApplicationHistory,
+  updateEligiblePiiRedaction,
+} from "../../../../app/api/applications.js";
+import { getContactHistory, displayContactHistory } from "../../../../app/api/contact-history.js";
+import { getClaimViewStates } from "../../../../app/routes/utils/get-claim-view-states.js";
 import { getPagination, getPagingData } from "../../../../app/pagination.js";
 import { createServer } from "../../../../app/server.js";
-import { claims } from "../../../data/claims.js";
+import { applicationsData } from "../../../data/applications.js";
+import { oldWorldApplication } from "../../../data/ow-application.js";
 import { StatusCodes } from "http-status-codes";
-import { updateEligiblePiiRedaction } from "../../../../app/api/applications.js";
 
 jest.mock("../../../../app/session");
 jest.mock("../../../../app/api/claims");
+jest.mock("../../../../app/api/applications");
+jest.mock("../../../../app/api/contact-history");
 jest.mock("../../../../app/pagination");
 jest.mock("../../../../app/routes/models/claim-list");
+jest.mock("../../../../app/routes/utils/get-claim-view-states");
 jest.mock("../../../../app/auth");
-jest.mock("../../../../app/api/applications");
 
-getPagination.mockReturnValue({
-  limit: 10,
-  offset: 0,
-});
-
-getPagingData.mockReturnValue({
-  page: 1,
-  totalPages: 1,
-  total: 1,
-  limit: 10,
-});
-
-getClaims.mockReturnValue(claims);
+getPagination.mockReturnValue({ limit: 10, offset: 0 });
+getPagingData.mockReturnValue({ page: 1, totalPages: 1, total: 1, limit: 10 });
 
 const { administrator } = permissions;
 
@@ -49,6 +49,15 @@ describe("get-applications-to-redact", () => {
     beforeEach(async () => {
       crumb = await getCrumbs(server);
       jest.clearAllMocks();
+      getClaims.mockReturnValue({ claims: [], total: 0 });
+      getContactHistory.mockReturnValue([]);
+      displayContactHistory.mockReturnValue({
+        email: "NA",
+        orgEmail: "NA",
+        farmerName: "NA",
+        address: "NA",
+      });
+      getClaimViewStates.mockReturnValue({});
     });
 
     test("returns 302 no auth", async () => {
@@ -106,8 +115,8 @@ describe("get-applications-to-redact", () => {
       expect(res.headers.location).toBe("/view-agreement/AHWR-U6ZE-5R5E?page=1");
     });
 
-    test("redirects to new world agreement with errors when new world reference", async () => {
-      updateEligiblePiiRedaction.mockResolvedValueOnce();
+    test("re-renders the new world agreement view in place with errors when new world reference", async () => {
+      getApplication.mockReturnValue(applicationsData.applications[0]);
       const options = {
         method: "POST",
         url,
@@ -122,17 +131,18 @@ describe("get-applications-to-redact", () => {
       };
 
       const res = await server.inject(options);
+      const $ = cheerio.load(res.payload);
 
-      expect(res.statusCode).toBe(StatusCodes.MOVED_TEMPORARILY);
-      expect(res.headers.location).toEqual(
-        expect.stringContaining(
-          "/agreement/IAHW-U6ZE-5R5E/claims?page=1&updateEligiblePiiRedaction=true&errors=",
-        ),
-      );
+      expect(res.statusCode).toBe(StatusCodes.OK);
+      expect(res.headers.location).toBeUndefined();
+      expect(res.payload).not.toContain("errors=");
+      expect($(".govuk-error-summary").text()).toContain("Enter note");
+      expect(await axe(res.payload)).toHaveNoViolations();
     });
 
-    test("redirects to old world agreement with errors when old world reference", async () => {
-      updateEligiblePiiRedaction.mockResolvedValueOnce();
+    test("re-renders the old world agreement view in place with errors when old world reference", async () => {
+      getApplication.mockReturnValue(oldWorldApplication);
+      getOldWorldApplicationHistory.mockReturnValue({ historyRecords: [] });
       const options = {
         method: "POST",
         url,
@@ -147,13 +157,12 @@ describe("get-applications-to-redact", () => {
       };
 
       const res = await server.inject(options);
+      const $ = cheerio.load(res.payload);
 
-      expect(res.statusCode).toBe(StatusCodes.MOVED_TEMPORARILY);
-      expect(res.headers.location).toEqual(
-        expect.stringContaining(
-          "/view-agreement/AHWR-U6ZE-5R5E?page=1&updateEligiblePiiRedaction=true&errors=",
-        ),
-      );
+      expect(res.statusCode).toBe(StatusCodes.OK);
+      expect(res.headers.location).toBeUndefined();
+      expect(res.payload).not.toContain("errors=");
+      expect($(".govuk-error-summary").text()).toContain("Enter note");
     });
   });
 });

--- a/test/integration/narrow/routes/approve-application-claim.test.js
+++ b/test/integration/narrow/routes/approve-application-claim.test.js
@@ -5,12 +5,14 @@ import { getCrumbs } from "../../../utils/get-crumbs.js";
 import { createServer } from "../../../../app/server.js";
 import { StatusCodes } from "http-status-codes";
 import { preSubmissionHandler } from "../../../../app/routes/utils/pre-submission-handler.js";
+import { setupViewClaimRender } from "../../../utils/view-claim-render-fixtures.js";
 import boom from "@hapi/boom";
 
 jest.mock("../../../../app/auth");
 jest.mock("../../../../app/api/applications");
 jest.mock("../../../../app/api/claims");
 jest.mock("../../../../app/routes/utils/pre-submission-handler");
+jest.mock("../../../../app/routes/utils/get-claim-view-states");
 
 preSubmissionHandler.mockImplementation((_arg, h) => h.continue);
 
@@ -36,6 +38,7 @@ describe("/approve-application-claim", () => {
   beforeEach(async () => {
     crumb = await getCrumbs(server);
     jest.clearAllMocks();
+    setupViewClaimRender();
   });
 
   describe(`POST ${url} route`, () => {
@@ -102,9 +105,7 @@ describe("/approve-application-claim", () => {
       preSubmissionHandler.mockImplementation((_arg, h) => h.continue);
     });
 
-    test("Approve application invalid reference", async () => {
-      const errors =
-        "W3sidGV4dCI6IlwicmVmZXJlbmNlXCIgbXVzdCBiZSBhIHN0cmluZyIsImhyZWYiOiIjYXV0aG9yaXNlIiwia2V5IjoicmVmZXJlbmNlIn1d";
+    test("re-renders the claim view in place on invalid reference", async () => {
       auth = {
         strategy: "session-auth",
         credentials: {
@@ -128,10 +129,10 @@ describe("/approve-application-claim", () => {
 
       const res = await server.inject(options);
 
-      expect(res.statusCode).toBe(StatusCodes.MOVED_TEMPORARILY);
-      expect(res.headers.location).toEqual(
-        `/view-claim/123?page=1&approve=true&errors=${errors}&returnPage=claims`,
-      );
+      expect(res.statusCode).toBe(StatusCodes.OK);
+      expect(res.headers.location).toBeUndefined();
+      expect(res.payload).not.toContain("errors=");
+      expect(res.payload).toContain("govuk-error-summary");
     });
 
     test.each([
@@ -165,9 +166,7 @@ describe("/approve-application-claim", () => {
       expect(res.headers.location).toEqual(`/view-claim/${reference}?page=1&returnPage=claims`);
     });
 
-    test("Approve application claim not processed", async () => {
-      const errors =
-        "W3sidGV4dCI6IlwiY29uZmlybVwiIGRvZXMgbm90IGNvbnRhaW4gMSByZXF1aXJlZCB2YWx1ZShzKSIsImhyZWYiOiIjYXV0aG9yaXNlIiwia2V5IjoiY29uZmlybSJ9XQ%3D%3D";
+    test("re-renders the claim view in place when claim not processed", async () => {
       const options = {
         method: "POST",
         url,
@@ -182,10 +181,10 @@ describe("/approve-application-claim", () => {
         },
       };
       const res = await server.inject(options);
-      expect(res.statusCode).toBe(StatusCodes.MOVED_TEMPORARILY);
-      expect(res.headers.location).toEqual(
-        `/view-claim/${reference}?page=1&approve=true&errors=${errors}&returnPage=claims`,
-      );
+      expect(res.statusCode).toBe(StatusCodes.OK);
+      expect(res.headers.location).toBeUndefined();
+      expect(res.payload).not.toContain("errors=");
+      expect(res.payload).toContain("govuk-error-summary");
     });
 
     test("If user is not administrator or authoriser", async () => {

--- a/test/integration/narrow/routes/claims-data.test.js
+++ b/test/integration/narrow/routes/claims-data.test.js
@@ -1,8 +1,10 @@
 import { getCrumbs } from "../../../utils/get-crumbs.js";
 import { permissions } from "../../../../app/auth/permissions.js";
-import { claims } from "../../../data/claims.js";
-import { getClaims, updateClaimData } from "../../../../app/api/claims.js";
+import * as cheerio from "cheerio";
+import { axe } from "../../../helpers/axe-helper.js";
+import { updateClaimData } from "../../../../app/api/claims.js";
 import { updateApplicationData } from "../../../../app/api/applications.js";
+import { setupViewClaimRender } from "../../../utils/view-claim-render-fixtures.js";
 import { getPagination, getPagingData } from "../../../../app/pagination.js";
 import { createServer } from "../../../../app/server.js";
 import { StatusCodes } from "http-status-codes";
@@ -14,6 +16,7 @@ jest.mock("../../../../app/api/claims");
 jest.mock("../../../../app/api/applications");
 jest.mock("../../../../app/pagination");
 jest.mock("../../../../app/routes/models/claim-list");
+jest.mock("../../../../app/routes/utils/get-claim-view-states");
 jest.mock("../../../../app/auth");
 
 getPagination.mockReturnValue({
@@ -27,7 +30,6 @@ getPagingData.mockReturnValue({
   total: 1,
   limit: 10,
 });
-getClaims.mockReturnValue(claims);
 
 describe("Claims data tests", () => {
   const auth = {
@@ -46,6 +48,7 @@ describe("Claims data tests", () => {
     beforeEach(async () => {
       crumb = await getCrumbs(server);
       jest.clearAllMocks();
+      setupViewClaimRender();
     });
 
     test("returns 302 no auth", async () => {
@@ -250,7 +253,7 @@ describe("Claims data tests", () => {
       );
     });
 
-    test("returns 302 with an error message for an invalid rcvs", async () => {
+    test("re-renders the claim view in place with an error for an invalid rcvs", async () => {
       const options = {
         method: "POST",
         url: "/claims/data",
@@ -269,15 +272,19 @@ describe("Claims data tests", () => {
         },
       };
       const res = await server.inject(options);
-      expect(res.statusCode).toBe(StatusCodes.MOVED_TEMPORARILY);
+      const $ = cheerio.load(res.payload);
 
-      expect(res.headers.location).toMatch(
-        /view-claim\/AAAA\?page=1&updateVetRCVSNumber=true&errors=.+&returnPage=claims/,
+      expect(res.statusCode).toBe(StatusCodes.OK);
+      expect(res.headers.location).toBeUndefined();
+      expect(res.payload).not.toContain("errors=");
+      expect($(".govuk-error-summary").length).toBe(1);
+      expect($(".govuk-error-summary").text()).toContain(
+        "Vet's RCVS number should be a 7 digit number or 6 digit number ending with a letter",
       );
       expect(updateApplicationData).toHaveBeenCalledTimes(0);
     });
 
-    test("returns 302 with an error message when visitDate moved after payment rate change", async () => {
+    test("re-renders the claim view in place when visitDate moved after payment rate change", async () => {
       const options = {
         method: "POST",
         url: "/claims/data",
@@ -297,15 +304,19 @@ describe("Claims data tests", () => {
         },
       };
       const res = await server.inject(options);
-      expect(res.statusCode).toBe(StatusCodes.MOVED_TEMPORARILY);
+      const $ = cheerio.load(res.payload);
 
-      expect(res.headers.location).toMatch(
-        /view-claim\/AAAA\?page=1&updateDateOfVisit=true&errors=.+&returnPage=claims/,
+      expect(res.statusCode).toBe(StatusCodes.OK);
+      expect(res.headers.location).toBeUndefined();
+      expect(res.payload).not.toContain("errors=");
+      expect($(".govuk-error-summary").text()).toContain(
+        "The date of visit cannot be moved after the payment rate change",
       );
+      expect(await axe(res.payload)).toHaveNoViolations();
       expect(updateApplicationData).toHaveBeenCalledTimes(0);
     });
 
-    test("returns 302 with an error message when visitDate moved before payment rate change", async () => {
+    test("re-renders the claim view in place when visitDate moved before payment rate change", async () => {
       const options = {
         method: "POST",
         url: "/claims/data",
@@ -325,10 +336,13 @@ describe("Claims data tests", () => {
         },
       };
       const res = await server.inject(options);
-      expect(res.statusCode).toBe(StatusCodes.MOVED_TEMPORARILY);
+      const $ = cheerio.load(res.payload);
 
-      expect(res.headers.location).toMatch(
-        /view-claim\/AAAA\?page=1&updateDateOfVisit=true&errors=.+&returnPage=claims/,
+      expect(res.statusCode).toBe(StatusCodes.OK);
+      expect(res.headers.location).toBeUndefined();
+      expect(res.payload).not.toContain("errors=");
+      expect($(".govuk-error-summary").text()).toContain(
+        "The date of visit cannot be moved before the payment rate change",
       );
       expect(updateApplicationData).toHaveBeenCalledTimes(0);
     });

--- a/test/integration/narrow/routes/claims-data.test.js
+++ b/test/integration/narrow/routes/claims-data.test.js
@@ -277,7 +277,7 @@ describe("Claims data tests", () => {
       expect(res.statusCode).toBe(StatusCodes.OK);
       expect(res.headers.location).toBeUndefined();
       expect(res.payload).not.toContain("errors=");
-      expect($(".govuk-error-summary").length).toBe(1);
+      expect($(".govuk-error-summary")).toHaveLength(1);
       expect($(".govuk-error-summary").text()).toContain(
         "Vet's RCVS number should be a 7 digit number or 6 digit number ending with a letter",
       );

--- a/test/integration/narrow/routes/move-to-in-check.test.js
+++ b/test/integration/narrow/routes/move-to-in-check.test.js
@@ -8,11 +8,13 @@ import { StatusCodes } from "http-status-codes";
 import { preSubmissionHandler } from "../../../../app/routes/utils/pre-submission-handler.js";
 import boom from "@hapi/boom";
 import { updateClaimStatus } from "../../../../app/api/claims.js";
+import { setupViewClaimRender } from "../../../utils/view-claim-render-fixtures.js";
 
 jest.mock("../../../../app/auth");
 jest.mock("../../../../app/api/applications");
 jest.mock("../../../../app/api/claims");
 jest.mock("../../../../app/routes/utils/pre-submission-handler");
+jest.mock("../../../../app/routes/utils/get-claim-view-states");
 
 preSubmissionHandler.mockImplementation((_arg, h) => h.continue);
 updateApplicationStatus.mockResolvedValue(true);
@@ -43,6 +45,7 @@ describe("Reject On Hold (move to In Check) Application test", () => {
   beforeEach(async () => {
     crumb = await getCrumbs(server);
     jest.clearAllMocks();
+    setupViewClaimRender();
   });
 
   describe(`POST ${url} route`, () => {
@@ -158,13 +161,10 @@ describe("Reject On Hold (move to In Check) Application test", () => {
       };
 
       const res = await server.inject(options);
-      expect(res.statusCode).toBe(StatusCodes.MOVED_TEMPORARILY);
-      const encodedErrors =
-        "W3sidGV4dCI6IlwicmVmZXJlbmNlXCIgbXVzdCBiZSBhIHN0cmluZyIsImhyZWYiOiIjbW92ZS10by1pbi1jaGVjayIsImtleSI6InJlZmVyZW5jZSJ9XQ%3D%3D";
-
-      expect(res.headers.location).toEqual(
-        `/view-claim/123?page=1&moveToInCheck=true&errors=${encodedErrors}&returnPage=claims`,
-      );
+      expect(res.statusCode).toBe(StatusCodes.OK);
+      expect(res.headers.location).toBeUndefined();
+      expect(res.payload).not.toContain("errors=");
+      expect(res.payload).toContain("govuk-error-summary");
     });
 
     test("Reject claim with one unchecked checkbox", async () => {
@@ -190,12 +190,10 @@ describe("Reject On Hold (move to In Check) Application test", () => {
       };
 
       const res = await server.inject(options);
-      expect(res.statusCode).toBe(StatusCodes.MOVED_TEMPORARILY);
-      const encodedErrors =
-        "W3sidGV4dCI6IlwiY29uZmlybVwiIGRvZXMgbm90IGNvbnRhaW4gMSByZXF1aXJlZCB2YWx1ZShzKSIsImhyZWYiOiIjbW92ZS10by1pbi1jaGVjayIsImtleSI6ImNvbmZpcm0ifV0%3D";
-      expect(res.headers.location).toEqual(
-        `/view-claim/${reference}?page=1&moveToInCheck=true&errors=${encodedErrors}&returnPage=claims`,
-      );
+      expect(res.statusCode).toBe(StatusCodes.OK);
+      expect(res.headers.location).toBeUndefined();
+      expect(res.payload).not.toContain("errors=");
+      expect(res.payload).toContain("govuk-error-summary");
     });
 
     test("Reject claim invalid permission", async () => {
@@ -244,12 +242,12 @@ describe("Reject On Hold (move to In Check) Application test", () => {
         },
       };
       const res = await server.inject(options);
-      expect(res.statusCode).toBe(StatusCodes.MOVED_TEMPORARILY);
+      expect(res.statusCode).toBe(StatusCodes.OK);
       expect(updateClaimStatus).not.toHaveBeenCalled();
     });
   });
 
-  test("returns 400 Bad Request", async () => {
+  test("returns 200 and re-renders in place on validation failure", async () => {
     const options = {
       method: "POST",
       url,
@@ -262,13 +260,11 @@ describe("Reject On Hold (move to In Check) Application test", () => {
       },
     };
     const res = await server.inject(options);
-    expect(res.statusCode).toBe(StatusCodes.MOVED_TEMPORARILY);
+    expect(res.statusCode).toBe(StatusCodes.OK);
     expect(updateClaimStatus).not.toHaveBeenCalled();
   });
 
-  test("Redirect to view claim with 302 status", async () => {
-    const encodedErrors =
-      "W3sidGV4dCI6IlNlbGVjdCBhbGwgY2hlY2tib3hlcyIsImhyZWYiOiIjbW92ZS10by1pbi1jaGVjayIsImtleSI6ImNvbmZpcm0ifV0%3D";
+  test("re-renders the claim view in place with the error summary on validation failure", async () => {
     const options = {
       method: "POST",
       url,
@@ -282,10 +278,10 @@ describe("Reject On Hold (move to In Check) Application test", () => {
       },
     };
     const res = await server.inject(options);
-    expect(res.statusCode).toBe(StatusCodes.MOVED_TEMPORARILY);
+    expect(res.statusCode).toBe(StatusCodes.OK);
     expect(updateClaimStatus).not.toHaveBeenCalled();
-    expect(res.headers.location).toEqual(
-      `/view-claim/${reference}?page=1&moveToInCheck=true&errors=${encodedErrors}&returnPage=claims`,
-    );
+    expect(res.headers.location).toBeUndefined();
+    expect(res.payload).not.toContain("errors=");
+    expect(res.payload).toContain("govuk-error-summary");
   });
 });

--- a/test/integration/narrow/routes/recommend-to-pay.test.js
+++ b/test/integration/narrow/routes/recommend-to-pay.test.js
@@ -2,10 +2,13 @@ import { permissions } from "../../../../app/auth/permissions.js";
 import { getCrumbs } from "../../../utils/get-crumbs.js";
 import { createServer } from "../../../../app/server.js";
 import { generateNewCrumb } from "../../../../app/routes/utils/crumb-cache.js";
+import { setupViewClaimRender } from "../../../utils/view-claim-render-fixtures.js";
 import { StatusCodes } from "http-status-codes";
 
 jest.mock("../../../../app/api/claims");
+jest.mock("../../../../app/api/applications");
 jest.mock("../../../../app/routes/utils/crumb-cache");
+jest.mock("../../../../app/routes/utils/get-claim-view-states");
 jest.mock("../../../../app/auth");
 
 const reference = "AHWR-555A-FD4C";
@@ -31,6 +34,7 @@ describe("Recommended To Pay test", () => {
   beforeEach(async () => {
     crumb = await getCrumbs(server);
     jest.clearAllMocks();
+    setupViewClaimRender();
   });
 
   describe(`POST ${url} route`, () => {
@@ -43,9 +47,7 @@ describe("Recommended To Pay test", () => {
       expect(res.statusCode).toBe(StatusCodes.MOVED_TEMPORARILY);
     });
 
-    test("returns 302 when validation fails for claim", async () => {
-      const errors =
-        "W3sidGV4dCI6IlNlbGVjdCBhbGwgY2hlY2tib3hlcyIsImhyZWYiOiIjcmVjb21tZW5kLXRvLXBheSIsImtleSI6ImNvbmZpcm0ifV0%3D";
+    test("re-renders the claim view in place when validation fails for claim", async () => {
       const options = {
         method: "POST",
         url,
@@ -60,10 +62,10 @@ describe("Recommended To Pay test", () => {
         },
       };
       const res = await server.inject(options);
-      expect(res.statusCode).toBe(StatusCodes.MOVED_TEMPORARILY);
-      expect(res.headers.location).toEqual(
-        `/view-claim/${reference}?page=1&recommendToPay=true&errors=${errors}&returnPage=claims`,
-      );
+      expect(res.statusCode).toBe(StatusCodes.OK);
+      expect(res.headers.location).toBeUndefined();
+      expect(res.payload).not.toContain("errors=");
+      expect(res.payload).toContain("govuk-error-summary");
     });
 
     test.each([recommender, administrator])(
@@ -120,9 +122,7 @@ describe("Recommended To Pay test", () => {
       expect(res.statusCode).toBe(StatusCodes.FORBIDDEN);
     });
 
-    test("Returns 302 on wrong payload", async () => {
-      const errors =
-        "W3sidGV4dCI6IlwiY29uZmlybVwiIGRvZXMgbm90IGNvbnRhaW4gMSByZXF1aXJlZCB2YWx1ZShzKSIsImhyZWYiOiIjcmVjb21tZW5kLXRvLXBheSIsImtleSI6ImNvbmZpcm0ifV0%3D";
+    test("re-renders the claim view in place on wrong payload", async () => {
       auth = {
         strategy: "session-auth",
         credentials: {
@@ -143,15 +143,13 @@ describe("Recommended To Pay test", () => {
         },
       };
       const res = await server.inject(options);
-      expect(res.statusCode).toBe(StatusCodes.MOVED_TEMPORARILY);
-      expect(res.headers.location).toEqual(
-        `/view-claim/${reference}?page=1&recommendToPay=true&errors=${errors}&returnPage=undefined`,
-      );
+      expect(res.statusCode).toBe(StatusCodes.OK);
+      expect(res.headers.location).toBeUndefined();
+      expect(res.payload).not.toContain("errors=");
+      expect(res.payload).toContain("govuk-error-summary");
     });
 
-    test("Recommended to pay invalid reference", async () => {
-      const errors =
-        "W3sidGV4dCI6IlwiY29uZmlybVswXVwiIGRvZXMgbm90IG1hdGNoIGFueSBvZiB0aGUgYWxsb3dlZCB0eXBlcyIsImhyZWYiOiIjcmVjb21tZW5kLXRvLXBheSIsImtleSI6MH0seyJ0ZXh0IjoiXCJjb25maXJtXCIgZG9lcyBub3QgY29udGFpbiAxIHJlcXVpcmVkIHZhbHVlKHMpIiwiaHJlZiI6IiNyZWNvbW1lbmQtdG8tcGF5Iiwia2V5IjoiY29uZmlybSJ9LHsidGV4dCI6IlwicmVmZXJlbmNlXCIgbXVzdCBiZSBhIHN0cmluZyIsImhyZWYiOiIjcmVjb21tZW5kLXRvLXBheSIsImtleSI6InJlZmVyZW5jZSJ9XQ%3D%3D";
+    test("re-renders the claim view in place on invalid reference", async () => {
       auth = {
         strategy: "session-auth",
         credentials: {
@@ -174,10 +172,10 @@ describe("Recommended To Pay test", () => {
 
       const res = await server.inject(options);
 
-      expect(res.statusCode).toBe(StatusCodes.MOVED_TEMPORARILY);
-      expect(res.headers.location).toEqual(
-        `/view-claim/123?page=1&recommendToPay=true&errors=${errors}&returnPage=undefined`,
-      );
+      expect(res.statusCode).toBe(StatusCodes.OK);
+      expect(res.headers.location).toBeUndefined();
+      expect(res.payload).not.toContain("errors=");
+      expect(res.payload).toContain("govuk-error-summary");
     });
   });
 });

--- a/test/integration/narrow/routes/recommend-to-reject.test.js
+++ b/test/integration/narrow/routes/recommend-to-reject.test.js
@@ -3,18 +3,18 @@ import { permissions } from "../../../../app/auth/permissions.js";
 import { generateNewCrumb } from "../../../../app/routes/utils/crumb-cache.js";
 import { createServer } from "../../../../app/server.js";
 import { getCrumbs } from "../../../utils/get-crumbs.js";
+import { setupViewClaimRender } from "../../../utils/view-claim-render-fixtures.js";
 
 const { administrator, recommender } = permissions;
 
 jest.mock("../../../../app/api/applications");
 jest.mock("../../../../app/api/claims");
 jest.mock("../../../../app/routes/utils/crumb-cache");
+jest.mock("../../../../app/routes/utils/get-claim-view-states");
 jest.mock("../../../../app/auth");
 
 const reference = "AHWR-555A-FD4C";
 const url = "/recommend-to-reject";
-const encodedErrors =
-  "W3sidGV4dCI6IlNlbGVjdCBhbGwgY2hlY2tib3hlcyIsImhyZWYiOiIjcmVjb21tZW5kLXRvLXJlamVjdCIsImtleSI6ImNvbmZpcm0ifV0%3D";
 
 describe("Recommended To Reject test", () => {
   let crumb;
@@ -34,6 +34,7 @@ describe("Recommended To Reject test", () => {
   beforeEach(async () => {
     crumb = await getCrumbs(server);
     jest.clearAllMocks();
+    setupViewClaimRender();
   });
 
   describe(`POST ${url} route`, () => {
@@ -46,7 +47,7 @@ describe("Recommended To Reject test", () => {
       expect(res.statusCode).toBe(StatusCodes.MOVED_TEMPORARILY);
     });
 
-    test("returns 302 when validation fails - no page given for claim", async () => {
+    test("re-renders the claim view in place when validation fails for claim", async () => {
       const options = {
         method: "POST",
         url,
@@ -61,10 +62,10 @@ describe("Recommended To Reject test", () => {
         },
       };
       const res = await server.inject(options);
-      expect(res.statusCode).toBe(StatusCodes.MOVED_TEMPORARILY);
-      expect(res.headers.location).toEqual(
-        `/view-claim/${reference}?page=1&recommendToReject=true&errors=${encodedErrors}&returnPage=claims`,
-      );
+      expect(res.statusCode).toBe(StatusCodes.OK);
+      expect(res.headers.location).toBeUndefined();
+      expect(res.payload).not.toContain("errors=");
+      expect(res.payload).toContain("govuk-error-summary");
     });
 
     test.each([

--- a/test/integration/narrow/routes/reject-application-claim.test.js
+++ b/test/integration/narrow/routes/reject-application-claim.test.js
@@ -5,18 +5,18 @@ import { permissions } from "../../../../app/auth/permissions.js";
 import { getCrumbs } from "../../../utils/get-crumbs.js";
 import { StatusCodes } from "http-status-codes";
 import { preSubmissionHandler } from "../../../../app/routes/utils/pre-submission-handler.js";
+import { setupViewClaimRender } from "../../../utils/view-claim-render-fixtures.js";
 import boom from "@hapi/boom";
 
 jest.mock("../../../../app/auth");
 jest.mock("../../../../app/api/applications");
 jest.mock("../../../../app/api/claims");
 jest.mock("../../../../app/routes/utils/pre-submission-handler");
+jest.mock("../../../../app/routes/utils/get-claim-view-states");
 
 preSubmissionHandler.mockImplementation((_arg, h) => h.continue);
 
 const reference = "AHWR-555A-FD4C";
-const encodedErrors =
-  "W3sidGV4dCI6IlNlbGVjdCBhbGwgY2hlY2tib3hlcyIsImhyZWYiOiIjcmVqZWN0Iiwia2V5IjoiY29uZmlybSJ9XQ%3D%3D";
 
 const { administrator, authoriser } = permissions;
 
@@ -37,6 +37,7 @@ describe("Reject Application test", () => {
   beforeEach(async () => {
     crumb = await getCrumbs(server);
     jest.clearAllMocks();
+    setupViewClaimRender();
   });
 
   describe(`POST ${url} route`, () => {
@@ -161,9 +162,7 @@ describe("Reject Application test", () => {
       expect(res.statusCode).toBe(StatusCodes.MOVED_TEMPORARILY);
     });
 
-    test("Reject application invalid reference", async () => {
-      const errors =
-        "W3sidGV4dCI6IlwicmVmZXJlbmNlXCIgbXVzdCBiZSBhIHN0cmluZyIsImhyZWYiOiIjcmVqZWN0Iiwia2V5IjoicmVmZXJlbmNlIn1d";
+    test("re-renders the claim view in place on invalid reference", async () => {
       auth = {
         strategy: "session-auth",
         credentials: {
@@ -187,15 +186,13 @@ describe("Reject Application test", () => {
 
       const res = await server.inject(options);
 
-      expect(res.statusCode).toBe(StatusCodes.MOVED_TEMPORARILY);
-      expect(res.headers.location).toEqual(
-        `/view-claim/123?page=1&reject=true&errors=${errors}&returnPage=claims`,
-      );
+      expect(res.statusCode).toBe(StatusCodes.OK);
+      expect(res.headers.location).toBeUndefined();
+      expect(res.payload).not.toContain("errors=");
+      expect(res.payload).toContain("govuk-error-summary");
     });
 
-    test("Reject application claim not processed", async () => {
-      const errors =
-        "W3sidGV4dCI6IlwiY29uZmlybVwiIGRvZXMgbm90IGNvbnRhaW4gMSByZXF1aXJlZCB2YWx1ZShzKSIsImhyZWYiOiIjcmVqZWN0Iiwia2V5IjoiY29uZmlybSJ9XQ%3D%3D";
+    test("re-renders the claim view in place when claim not processed", async () => {
       const options = {
         method: "POST",
         url,
@@ -210,14 +207,14 @@ describe("Reject Application test", () => {
         },
       };
       const res = await server.inject(options);
-      expect(res.statusCode).toBe(StatusCodes.MOVED_TEMPORARILY);
-      expect(res.headers.location).toEqual(
-        `/view-claim/${reference}?page=1&reject=true&errors=${errors}&returnPage=claims`,
-      );
+      expect(res.statusCode).toBe(StatusCodes.OK);
+      expect(res.headers.location).toBeUndefined();
+      expect(res.payload).not.toContain("errors=");
+      expect(res.payload).toContain("govuk-error-summary");
     });
   });
 
-  test("retuns 400 Bad Request for claim", async () => {
+  test("re-renders the claim view in place on validation failure for claim", async () => {
     const options = {
       method: "POST",
       url,
@@ -231,9 +228,9 @@ describe("Reject Application test", () => {
       },
     };
     const res = await server.inject(options);
-    expect(res.statusCode).toBe(StatusCodes.MOVED_TEMPORARILY);
-    expect(res.headers.location).toEqual(
-      `/view-claim/${reference}?page=1&reject=true&errors=${encodedErrors}&returnPage=claims`,
-    );
+    expect(res.statusCode).toBe(StatusCodes.OK);
+    expect(res.headers.location).toBeUndefined();
+    expect(res.payload).not.toContain("errors=");
+    expect(res.payload).toContain("govuk-error-summary");
   });
 });

--- a/test/integration/narrow/routes/update-status.test.js
+++ b/test/integration/narrow/routes/update-status.test.js
@@ -74,7 +74,7 @@ describe("update-status", () => {
     expect(res.statusCode).toBe(StatusCodes.OK);
     expect(res.headers.location).toBeUndefined();
     expect(res.payload).not.toContain("errors=");
-    expect($(".govuk-error-summary").length).toBe(1);
+    expect($(".govuk-error-summary")).toHaveLength(1);
     expect($(".govuk-error-summary").text()).toContain("Enter note");
     expect(await axe(res.payload)).toHaveNoViolations();
   });

--- a/test/integration/narrow/routes/update-status.test.js
+++ b/test/integration/narrow/routes/update-status.test.js
@@ -1,6 +1,9 @@
+import * as cheerio from "cheerio";
+import { axe } from "../../../helpers/axe-helper.js";
 import { createServer } from "../../../../app/server.js";
 import { permissions } from "../../../../app/auth/permissions.js";
 import { getCrumbs } from "../../../utils/get-crumbs.js";
+import { setupViewClaimRender } from "../../../utils/view-claim-render-fixtures.js";
 import { STATUS } from "ffc-ahwr-common-library";
 import { StatusCodes } from "http-status-codes";
 
@@ -9,84 +12,70 @@ const { administrator } = permissions;
 jest.mock("../../../../app/api/applications");
 jest.mock("../../../../app/api/claims");
 jest.mock("../../../../app/routes/utils/crumb-cache");
+jest.mock("../../../../app/routes/utils/get-claim-view-states");
 jest.mock("../../../../app/auth");
 
-test("success: update claim", async () => {
-  const server = await createServer();
+describe("update-status", () => {
+  let server;
   const auth = {
     strategy: "session-auth",
-    credentials: {
-      account: {},
-      scope: [administrator],
-    },
+    credentials: { account: {}, scope: [administrator] },
   };
-  const crumb = await getCrumbs(server);
 
-  const reference = "FUSH-1010-2020";
-  const returnPage = "claims";
-  const page = "1";
-
-  const res = await server.inject({
-    method: "post",
-    url: "/update-status",
-    auth,
-    headers: { cookie: `crumb=${crumb}` },
-    payload: {
-      reference,
-      page,
-      status: STATUS.IN_CHECK,
-      note: "test",
-      returnPage,
-      crumb,
-    },
+  beforeAll(async () => {
+    server = await createServer();
   });
 
-  expect(res.statusCode).toBe(StatusCodes.MOVED_TEMPORARILY);
-  expect(res.headers.location).toBe(
-    `/view-claim/${reference}?page=${page}&returnPage=${returnPage}`,
-  );
-});
-
-test("failure: update claim, missing note", async () => {
-  const server = await createServer();
-  const auth = {
-    strategy: "session-auth",
-    credentials: {
-      account: {},
-      scope: [administrator],
-    },
-  };
-  const crumb = await getCrumbs(server);
-
-  const reference = "FUSH-1010-2020";
-  const returnPage = "claims";
-  const page = "1";
-
-  const res = await server.inject({
-    method: "post",
-    url: "/update-status",
-    auth,
-    headers: { cookie: `crumb=${crumb}` },
-    payload: {
-      reference,
-      page,
-      status: STATUS.IN_CHECK,
-      returnPage,
-      crumb,
-    },
+  beforeEach(() => {
+    jest.clearAllMocks();
+    setupViewClaimRender();
   });
 
-  const errors = [
-    {
-      text: "Enter note",
-      href: "#update-status",
-      key: "note",
-    },
-  ];
-  const encodedErrors = Buffer.from(JSON.stringify(errors)).toString("base64");
+  test("success: redirects to the claim view (PRG preserved on the success path)", async () => {
+    const crumb = await getCrumbs(server);
 
-  expect(res.statusCode).toBe(StatusCodes.MOVED_TEMPORARILY);
-  expect(res.headers.location).toBe(
-    `/view-claim/${reference}?page=${page}&updateStatus=true&errors=${encodedErrors}&returnPage=${returnPage}`,
-  );
+    const res = await server.inject({
+      method: "post",
+      url: "/update-status",
+      auth,
+      headers: { cookie: `crumb=${crumb}` },
+      payload: {
+        reference: "FUSH-1010-2020",
+        page: "1",
+        status: STATUS.IN_CHECK,
+        note: "test",
+        returnPage: "claims",
+        crumb,
+      },
+    });
+
+    expect(res.statusCode).toBe(StatusCodes.MOVED_TEMPORARILY);
+    expect(res.headers.location).toBe("/view-claim/FUSH-1010-2020?page=1&returnPage=claims");
+  });
+
+  test("failure: re-renders the claim view in place with the error summary, no redirect, no errors in the URL", async () => {
+    const crumb = await getCrumbs(server);
+
+    const res = await server.inject({
+      method: "post",
+      url: "/update-status",
+      auth,
+      headers: { cookie: `crumb=${crumb}` },
+      payload: {
+        reference: "FUSH-1010-2020",
+        page: "1",
+        status: STATUS.IN_CHECK,
+        returnPage: "claims",
+        crumb,
+      },
+    });
+    const $ = cheerio.load(res.payload);
+
+    expect(res.statusCode).toBe(StatusCodes.OK);
+    expect(res.headers.location).toBeUndefined();
+    expect(res.payload).not.toContain("errors=");
+    expect($(".govuk-error-summary").length).toBe(1);
+    expect($(".govuk-error-summary").text()).toContain("Enter note");
+    expect(await axe(res.payload)).toHaveNoViolations();
+  });
 });

--- a/test/integration/narrow/routes/view-agreement.test.js
+++ b/test/integration/narrow/routes/view-agreement.test.js
@@ -1,0 +1,87 @@
+import * as cheerio from "cheerio";
+import { axe } from "../../../helpers/axe-helper.js";
+import { permissions } from "../../../../app/auth/permissions.js";
+import { oldWorldApplication } from "../../../data/ow-application.js";
+import { getApplication, getOldWorldApplicationHistory } from "../../../../app/api/applications.js";
+import { getContactHistory, displayContactHistory } from "../../../../app/api/contact-history.js";
+import { getClaimViewStates } from "../../../../app/routes/utils/get-claim-view-states.js";
+import { createServer } from "../../../../app/server.js";
+import { StatusCodes } from "http-status-codes";
+
+const { administrator } = permissions;
+
+jest.mock("../../../../app/api/applications");
+jest.mock("../../../../app/api/contact-history");
+jest.mock("../../../../app/routes/utils/get-claim-view-states");
+jest.mock("../../../../app/auth");
+
+describe("View agreement (old world) test", () => {
+  const url = "/view-agreement/AHWR-B571-6E79";
+  const auth = {
+    strategy: "session-auth",
+    credentials: { scope: [administrator], account: { username: "test user" } },
+  };
+
+  let server;
+
+  beforeAll(async () => {
+    server = await createServer();
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    getApplication.mockReturnValue(oldWorldApplication);
+    getOldWorldApplicationHistory.mockReturnValue({ historyRecords: [] });
+    getContactHistory.mockReturnValue([]);
+    displayContactHistory.mockReturnValue({
+      email: "NA",
+      orgEmail: "NA",
+      farmerName: "NA",
+      address: "NA",
+    });
+    getClaimViewStates.mockReturnValue({});
+  });
+
+  test("returns 302 no auth", async () => {
+    const res = await server.inject({ method: "GET", url });
+    expect(res.statusCode).toBe(StatusCodes.MOVED_TEMPORARILY);
+  });
+
+  test("returns 200 and is accessible, with no error summary on a clean GET", async () => {
+    const res = await server.inject({ method: "GET", url, auth });
+    const $ = cheerio.load(res.payload);
+
+    expect(res.statusCode).toBe(StatusCodes.OK);
+    expect(await axe(res.payload)).toHaveNoViolations();
+    expect($(".govuk-error-summary").length).toBe(0);
+  });
+
+  test("renders the Change action links when the user can edit the agreement", async () => {
+    getClaimViewStates.mockReturnValue({
+      updateVetsNameAction: true,
+      updateVetRCVSNumberAction: true,
+      updateDateOfVisitAction: true,
+      updateEligiblePiiRedactionAction: true,
+    });
+
+    const res = await server.inject({ method: "GET", url, auth });
+    const $ = cheerio.load(res.payload);
+
+    expect(res.statusCode).toBe(StatusCodes.OK);
+    expect(await axe(res.payload)).toHaveNoViolations();
+    expect($(".govuk-summary-list__actions").text()).toContain("Change");
+  });
+
+  test("ignores an errors query parameter added manually to the URL", async () => {
+    const injected = Buffer.from(
+      JSON.stringify([{ text: "Injected link", href: "#x", key: "y" }]),
+    ).toString("base64");
+
+    const res = await server.inject({ method: "GET", url: `${url}?errors=${injected}`, auth });
+    const $ = cheerio.load(res.payload);
+
+    expect(res.statusCode).toBe(StatusCodes.OK);
+    expect($(".govuk-error-summary").length).toBe(0);
+    expect(res.payload).not.toContain("Injected link");
+  });
+});

--- a/test/integration/narrow/routes/view-agreement.test.js
+++ b/test/integration/narrow/routes/view-agreement.test.js
@@ -53,7 +53,7 @@ describe("View agreement (old world) test", () => {
 
     expect(res.statusCode).toBe(StatusCodes.OK);
     expect(await axe(res.payload)).toHaveNoViolations();
-    expect($(".govuk-error-summary").length).toBe(0);
+    expect($(".govuk-error-summary")).toHaveLength(0);
   });
 
   test("renders the Change action links when the user can edit the agreement", async () => {
@@ -81,7 +81,7 @@ describe("View agreement (old world) test", () => {
     const $ = cheerio.load(res.payload);
 
     expect(res.statusCode).toBe(StatusCodes.OK);
-    expect($(".govuk-error-summary").length).toBe(0);
+    expect($(".govuk-error-summary")).toHaveLength(0);
     expect(res.payload).not.toContain("Injected link");
   });
 });

--- a/test/integration/narrow/routes/view-claim.test.js
+++ b/test/integration/narrow/routes/view-claim.test.js
@@ -381,7 +381,7 @@ describe("View claim test", () => {
       const $ = cheerio.load(res.payload);
 
       expect(res.statusCode).toBe(StatusCodes.OK);
-      expect($(".govuk-error-summary").length).toBe(0);
+      expect($(".govuk-error-summary")).toHaveLength(0);
       expect(res.payload).not.toContain("Injected link");
     });
 

--- a/test/integration/narrow/routes/view-claim.test.js
+++ b/test/integration/narrow/routes/view-claim.test.js
@@ -365,6 +365,26 @@ describe("View claim test", () => {
       expect(res.statusCode).toBe(StatusCodes.MOVED_TEMPORARILY);
     });
 
+    test("ignores an errors query parameter added manually to the URL", async () => {
+      getClaim.mockReturnValue(claims[0]);
+      getClaims.mockReturnValue({ claims });
+      getApplication.mockReturnValue(application);
+      const injected = Buffer.from(
+        JSON.stringify([{ text: "Injected link", href: "#x", key: "y" }]),
+      ).toString("base64");
+
+      const res = await server.inject({
+        method: "GET",
+        url: `${url}/AHWR-0000-4444?errors=${injected}`,
+        auth,
+      });
+      const $ = cheerio.load(res.payload);
+
+      expect(res.statusCode).toBe(StatusCodes.OK);
+      expect($(".govuk-error-summary").length).toBe(0);
+      expect(res.payload).not.toContain("Injected link");
+    });
+
     test("returns 200 with review claim type and Pigs species", async () => {
       const options = {
         method: "GET",

--- a/test/unit/routes/utils/format-errors-for-ui.test.js
+++ b/test/unit/routes/utils/format-errors-for-ui.test.js
@@ -1,0 +1,27 @@
+import { formatErrorsForUI } from "../../../../app/routes/utils/format-errors-for-ui.js";
+
+test("maps Joi error details to the view's text/href/key shape", () => {
+  const joiErrors = [{ message: "Enter note", context: { key: "note" } }];
+
+  const result = formatErrorsForUI(joiErrors, "#note");
+
+  expect(result).toEqual([{ text: "Enter note", href: "#note", key: "note" }]);
+});
+
+test("applies the same href to every error", () => {
+  const joiErrors = [
+    { message: "Enter day", context: { key: "day" } },
+    { message: "Enter month", context: { key: "month" } },
+  ];
+
+  const result = formatErrorsForUI(joiErrors, "#update-date-of-visit");
+
+  expect(result).toEqual([
+    { text: "Enter day", href: "#update-date-of-visit", key: "day" },
+    { text: "Enter month", href: "#update-date-of-visit", key: "month" },
+  ]);
+});
+
+test("returns an empty array when there are no errors", () => {
+  expect(formatErrorsForUI([], "#note")).toEqual([]);
+});

--- a/test/unit/routes/utils/get-form-flags.test.js
+++ b/test/unit/routes/utils/get-form-flags.test.js
@@ -1,0 +1,36 @@
+import { getFormFlags } from "../../../../app/routes/utils/get-form-flags.js";
+import { DEFAULT_FORM_FLAGS } from "../../../../app/routes/utils/get-claim-view-states.js";
+
+test("sets the named flag true and every other flag false", () => {
+  const flags = getFormFlags("updateStatus");
+
+  expect(flags.updateStatus).toBe(true);
+  expect(flags.updateVetsName).toBe(false);
+  expect(flags.recommendToPay).toBe(false);
+});
+
+test("opens none of the known forms when the key matches nothing", () => {
+  const flags = getFormFlags("notARealForm");
+
+  for (const key of Object.keys(DEFAULT_FORM_FLAGS)) {
+    expect(flags[key]).toBe(false);
+  }
+});
+
+test("covers every form flag getClaimViewStates reads", () => {
+  expect(Object.keys(getFormFlags("updateStatus"))).toEqual(
+    expect.arrayContaining([
+      "withdraw",
+      "moveToInCheck",
+      "recommendToPay",
+      "recommendToReject",
+      "approve",
+      "reject",
+      "updateStatus",
+      "updateVetsName",
+      "updateDateOfVisit",
+      "updateVetRCVSNumber",
+      "updateEligiblePiiRedaction",
+    ]),
+  );
+});

--- a/test/utils/view-claim-render-fixtures.js
+++ b/test/utils/view-claim-render-fixtures.js
@@ -1,0 +1,43 @@
+import { getClaim, getClaims, getClaimHistory } from "../../app/api/claims.js";
+import { getApplication } from "../../app/api/applications.js";
+import { getClaimViewStates } from "../../app/routes/utils/get-claim-view-states.js";
+
+const application = {
+  reference: "IAHW-1234-APP1",
+  organisation: {
+    sbi: "113494460",
+    name: "Test Farm Lodge",
+    email: "farmer@example.test",
+    orgEmail: "org@example.test",
+    address: "WHITE HOUSE FARM,LEIGHTON BUZZARD,HR2 8AN,United Kingdom",
+    farmerName: "Russell Davies",
+  },
+  createdAt: "2024-03-22T12:19:04.696Z",
+  flags: [],
+  redacted: false,
+};
+
+const claim = {
+  reference: "FUSH-1010-2020",
+  applicationReference: "IAHW-1234-APP1",
+  type: "REVIEW",
+  status: "IN_CHECK",
+  createdAt: "2024-03-22T12:20:18.307Z",
+  data: {
+    typeOfLivestock: "sheep",
+    dateOfVisit: "2024-03-22T00:00:00.000Z",
+    vetsName: "Vet one",
+    vetRCVSNumber: "1233211",
+  },
+};
+
+// Wires up the mocks the shared claim view (buildViewClaim) needs so a failing
+// claim-action POST can re-render the view in place. The caller must jest.mock
+// app/api/claims, app/api/applications and the get-claim-view-states util.
+export const setupViewClaimRender = () => {
+  getClaim.mockReturnValue(claim);
+  getClaims.mockReturnValue({ claims: [] });
+  getClaimHistory.mockResolvedValue({ historyRecords: [] });
+  getApplication.mockReturnValue(application);
+  getClaimViewStates.mockReturnValue({});
+};


### PR DESCRIPTION
## Summary

An IT Health Check flagged that the Backoffice UI reflected an unsanitised `errors` query parameter into the rendered page on failed form submissions, a reflected-injection risk. This hardens it by rendering validation errors in place on the target view instead of round-tripping them through the URL. Errors no longer appear in the URL at all, and a manually-added `errors` parameter is silently ignored.

The approach matches the error-handling pattern already used across the estate (the public UI, EPR, and the existing Create Flag screen).

## What Changed

- Failed claim and agreement form submissions now re-render the target page in place with the validation errors, instead of redirecting with the errors encoded in the URL.
- The `errors` query parameter is no longer read on those pages, so a hand-crafted value is ignored rather than decoded and reflected back.
- Error state no longer travels through the URL or the session; the page still reopens whichever form the user was editing, with the error summary shown and accessibility preserved.
- Updated and added integration and unit tests covering the in-place render, the ignored manual parameter, and accessibility, with some shared test-fixture tidy-up.

## Why

The penetration test recommended removing the reflected parameter. Rendering in place removes the injection vector entirely, keeps error state out of both the URL and the session, and brings the Backoffice UI into line with how the rest of the estate handles form errors. The user-facing outcome is unchanged: validation errors still appear on the page as before.