### PR TITLE
feat(agreements): (AHWR-2047) limit basic search to number, organisation and SBI

### DIFF
--- a/app/frontend/src/css/application.scss
+++ b/app/frontend/src/css/application.scss
@@ -157,6 +157,10 @@ $moj-assets-path: "~@ministryofjustice/frontend/moj/assets/";
   background-color: #003078;
 }
 
+.no-results-message {
+  color: $govuk-secondary-text-colour;
+}
+
 .filter-block {
   padding-top: 30px;
   border-top: 1px solid #b1b4b6;

--- a/app/lib/search-validation.js
+++ b/app/lib/search-validation.js
@@ -1,5 +1,7 @@
 import { regexChecker } from "../../app/routes/utils/regex-checker.js";
 
+export const UNSUPPORTED_SEARCH_TYPE = "unsupported";
+
 const refRegEx =
   /^(IAHW|AHWR|REPI|RESH|REBC|REDC|FUPI|FUSH|FUBC|FUDC|POUL|PORE)-[A-Z0-9]{4}-[A-Z0-9]{4}$/i;
 const dateRegEx = /^(0[1-9]|[12]\d|3[01])[- /.](0[1-9]|1[012])[- /.](19|20)\d\d$/; // DD/MM/YYYY
@@ -59,13 +61,13 @@ export const searchValidation = (searchText) => {
       searchType = "ref";
       break;
     case validStatus.indexOf(searchText.toLowerCase()) !== -1:
-      searchType = "status";
+      searchType = UNSUPPORTED_SEARCH_TYPE;
       break;
     case sbiRegEx.test(searchText):
       searchType = "sbi";
       break;
     case regexChecker(dateRegEx, searchText):
-      searchType = "date";
+      searchType = UNSUPPORTED_SEARCH_TYPE;
       break;
     case isValidSpecies:
       searchType = "species";

--- a/app/routes/models/application-list.js
+++ b/app/routes/models/application-list.js
@@ -6,8 +6,16 @@ import { getStyleClassByStatus } from "../../constants/status.js";
 import { upperFirstLetter } from "../../lib/display-helper.js";
 import { FLAG_EMOJI } from "../utils/ui-constants.js";
 import { config } from "../../config/index.js";
+import { UNSUPPORTED_SEARCH_TYPE } from "../../lib/search-validation.js";
 
 const { serviceUri } = config;
+
+const emptyModel = (searchText) => ({
+  applications: [],
+  total: 0,
+  error: "No agreements found.",
+  searchText,
+});
 
 export const viewModel = (request, page) => {
   return (async () => {
@@ -126,6 +134,11 @@ export async function createModel(request, page) {
   const { limit, offset } = getPagination(page);
   const searchText = getAppSearch(request, sessionKeys.appSearch.searchText);
   const searchType = getAppSearch(request, sessionKeys.appSearch.searchType);
+
+  if (searchType === UNSUPPORTED_SEARCH_TYPE) {
+    return emptyModel(searchText);
+  }
+
   const filterStatus = getAppSearch(request, sessionKeys.appSearch.filterStatus) ?? [];
   const sortField = getAppSearch(request, sessionKeys.appSearch.sort) ?? undefined;
   const apps = await getApplications(
@@ -151,10 +164,5 @@ export async function createModel(request, page) {
     };
   }
 
-  return {
-    applications: [],
-    total: 0,
-    error: "No agreements found.",
-    searchText,
-  };
+  return emptyModel(searchText);
 }

--- a/app/views/agreements.njk
+++ b/app/views/agreements.njk
@@ -32,7 +32,7 @@
                     <h1 class="govuk-heading-l">Agreements</h1>
                     <div class="user-search-box">
                       <label class="govuk-label govuk-label--s" for="searchText">Find an agreement</label>
-                      <div id="agreementSearch-hint" class="govuk-hint">Search by agreement number, organisation, SBI, agreement date or status.</div>
+                      <div id="agreementSearch-hint" class="govuk-hint">Search by agreement number, organisation or SBI.</div>
                       <input type="hidden" name="crumb" value="{{crumb}}"/>
                       <input class="govuk-input" id="searchText" name="searchText" type="text" value="{{model.searchText}}" spellcheck="false">
                       <button class="search-button" data-module="govuk-button" name="submit" value="search">
@@ -42,7 +42,7 @@
                   </div>
                   {% if model.error or error %}
                     <div class="govuk-grid-column-full">
-                      <p class="govuk-error-message">{{model.error}}{{error}}</p>
+                      <p class="govuk-body no-results-message">{{model.error}}{{error}}</p>
                     </div>
                   {% endif %}
                   <div class="govuk-grid-column-full">

--- a/test/integration/narrow/routes/agreements.test.js
+++ b/test/integration/narrow/routes/agreements.test.js
@@ -204,6 +204,21 @@ describe("Applications test", () => {
       expect(results.text()).toEqual("9 search results");
     });
 
+    test("search hint lists only agreement number, organisation and SBI", async () => {
+      const options = {
+        method: "GET",
+        url,
+        auth,
+      };
+      const res = await server.inject(options);
+      expect(res.statusCode).toBe(StatusCodes.OK);
+      const $ = cheerio.load(res.payload);
+      const hint = $("#agreementSearch-hint").text().trim();
+      expect(hint).toBe("Search by agreement number, organisation or SBI.");
+      expect(hint).not.toContain("date");
+      expect(hint).not.toContain("status");
+    });
+
     test("returns 200 clear", async () => {
       const options = {
         method: "GET",
@@ -251,43 +266,17 @@ describe("Applications test", () => {
     });
 
     test.each([
-      {
-        searchDetails: { searchText: "AHWR-555A-FD6E", searchType: "ref" },
-        status: ["APPLIED", "CLAIMED"],
-      },
-      {
-        searchDetails: { searchText: "applied", searchType: "status" },
-        status: "APPLIED",
-      },
-      {
-        searchDetails: { searchText: "claimed", searchType: "status" },
-        status: "CLAIMED",
-      },
-      {
-        searchDetails: { searchText: "check", searchType: "status" },
-        status: "CHECK",
-      },
-      {
-        searchDetails: { searchText: "accepted", searchType: "status" },
-        status: "ACCEPTED",
-      },
-      {
-        searchDetails: { searchText: "rejected", searchType: "status" },
-        status: "REJECTED",
-      },
-      {
-        searchDetails: { searchText: "paid", searchType: "status" },
-        status: "PAID",
-      },
-      { searchDetails: { searchText: "withdrawn", searchType: "status" } },
-    ])("returns success when post %p", async ({ searchDetails, status }) => {
+      { searchText: "AHWR-555A-FD6E" }, // agreement number
+      { searchText: "107279003" }, // sbi
+      { searchText: "Foxes Drove Farm" }, // organisation
+    ])("supported search ($searchText) posts and queries the backend", async ({ searchText }) => {
       const options = {
         method,
         url,
         payload: {
           crumb,
-          searchText: searchDetails.searchText,
-          status,
+          searchText,
+          status: [],
           submit: "search",
         },
         auth,
@@ -342,7 +331,9 @@ describe("Applications test", () => {
       expect(getApplications).toHaveBeenCalled();
       expect(getPagination).toHaveBeenCalled();
       const $ = cheerio.load(res.payload);
-      expect($("p.govuk-error-message").text()).toMatch("No agreements found.");
+      expect($("p.no-results-message").text()).toMatch("No agreements found.");
+      expect($("p.govuk-error-message")).toHaveLength(0);
+      expect($("p.govuk-body.govuk-\\!-font-weight-bold").text()).toEqual("0 search results");
     });
   });
 });

--- a/test/integration/narrow/routes/models/application-list.test.js
+++ b/test/integration/narrow/routes/models/application-list.test.js
@@ -71,5 +71,36 @@ describe("Application-list createModel", () => {
     };
     const result = await createModel(request, 1);
     expect(result.applications[0][5].html).toContain("Agreed");
+    expect(result.total).toBe(9);
+  });
+
+  test("createModel returns the empty state without querying the backend for an unsupported search type", async () => {
+    getApplications.mockClear();
+    const request = {
+      yar: {
+        get: jest.fn(() => ({
+          searchType: "unsupported",
+          searchText: "01/12/2024",
+        })),
+      },
+      query: {},
+      auth: {
+        isAuthenticated: true,
+        credentials: {
+          scope: [administrator],
+          account: { username: "unit-tester" },
+        },
+      },
+    };
+
+    const result = await createModel(request, 1);
+
+    expect(result).toEqual({
+      applications: [],
+      total: 0,
+      error: "No agreements found.",
+      searchText: "01/12/2024",
+    });
+    expect(getApplications).not.toHaveBeenCalled();
   });
 });

--- a/test/lib/search-validation.test.js
+++ b/test/lib/search-validation.test.js
@@ -11,7 +11,6 @@ describe("searchValidation", () => {
     { type: "organisation", text: "IAHW-1234" },
     { type: "organisation", text: "IAHW-ABCD-1234-EFGH" },
     { type: "sbi", text: "107279003" },
-    { type: "date", text: "01/12/2024" },
     { type: "organisation", text: "a string" },
     { type: "species", text: "sheep" },
     { type: "reset", text: "" },
@@ -20,29 +19,43 @@ describe("searchValidation", () => {
     expect(searchType).toBe(type);
     expect(searchText).toBe(text);
   });
-  test.each([
-    { status: "agreed" },
-    { status: "applied" },
-    { status: "withdrawn" },
-    { status: "inputted" },
-    { status: "claimed" },
-    { status: "in check" },
-    { status: "check" },
-    { status: "recommended" },
-    { status: "pay" },
-    { status: "recommended to pay" },
-    { status: "reject" },
-    { status: "recommended to reject" },
-    { status: "paid" },
-    { status: "rejected" },
-    { status: "not agreed" },
-    { status: "ready" },
-    { status: "ready to pay" },
-    { status: "hold" },
-    { status: "on hold" },
-  ])("A valid status ($status) should return $status and status as type", ({ status }) => {
-    const { searchText, searchType } = searchValidation(status);
-    expect(searchType).toBe("status");
-    expect(searchText).toBe(status);
+
+  describe("retired basic-search terms return 'unsupported'", () => {
+    test.each([
+      { text: "01/12/2024" },
+      { text: "31/12/2025" },
+      { text: "01-12-2024" },
+      { text: "01.12.2024" },
+    ])("a date ($text) is no longer a searchable term", ({ text }) => {
+      const { searchText, searchType } = searchValidation(text);
+      expect(searchType).toBe("unsupported");
+      expect(searchText).toBe(text);
+    });
+
+    test.each([
+      { status: "agreed" },
+      { status: "applied" },
+      { status: "withdrawn" },
+      { status: "inputted" },
+      { status: "claimed" },
+      { status: "in check" },
+      { status: "check" },
+      { status: "recommended" },
+      { status: "pay" },
+      { status: "recommended to pay" },
+      { status: "reject" },
+      { status: "recommended to reject" },
+      { status: "paid" },
+      { status: "rejected" },
+      { status: "not agreed" },
+      { status: "ready" },
+      { status: "ready to pay" },
+      { status: "hold" },
+      { status: "on hold" },
+    ])("a status ($status) is no longer a searchable term", ({ status }) => {
+      const { searchText, searchType } = searchValidation(status);
+      expect(searchType).toBe("unsupported");
+      expect(searchText).toBe(status);
+    });
   });
 });


### PR DESCRIPTION
## Summary
Rationalises the basic search on the Agreements tab so it matches only the terms users actually need, and tidies the surrounding content and empty-state styling. Agreement date and status are retired as basic-search terms (they will move to Advanced Search filters in later work), and searching by either now deterministically returns no results.

## What Changed
- Basic search now matches only agreement number, organisation and SBI.
- Searching by a date or a recognised status returns zero results and shows the "No agreements found" message, without querying the backend.
- Updated the search hint copy above the search bar to reflect the reduced set of terms.
- The result counter shows "0 search results" for searches that return nothing, including the retired terms.
- Recoloured the "No agreements found" message from error red to secondary-text grey.
- Added and updated unit and integration tests covering the new behaviour.

## Why
Part of the wider search enhancements: the existing basic search is being rationalised and improved ahead of an Advanced Search capability, with date and status becoming filters there rather than free-text search terms. The status filter chips are unaffected. The change is backoffice-only and backward compatible, with no backend change required.

## Screenshot
<img width="1196" height="591" alt="Screenshot 2026-07-10 at 15 46 46" src="https://github.com/user-attachments/assets/7425f476-7985-4238-8e7f-3ea8cbbe2a20" />
