### PR TITLE
fix(search): (AHWR-2047) restore claims date and status search #patch

### DIFF
--- a/app/lib/search-validation.js
+++ b/app/lib/search-validation.js
@@ -1,7 +1,5 @@
 import { regexChecker } from "../../app/routes/utils/regex-checker.js";
 
-export const UNSUPPORTED_SEARCH_TYPE = "unsupported";
-
 const refRegEx =
   /^(IAHW|AHWR|REPI|RESH|REBC|REDC|FUPI|FUSH|FUBC|FUDC|POUL|PORE)-[A-Z0-9]{4}-[A-Z0-9]{4}$/i;
 const dateRegEx = /^(0[1-9]|[12]\d|3[01])[- /.](0[1-9]|1[012])[- /.](19|20)\d\d$/; // DD/MM/YYYY
@@ -61,13 +59,13 @@ export const searchValidation = (searchText) => {
       searchType = "ref";
       break;
     case validStatus.indexOf(searchText.toLowerCase()) !== -1:
-      searchType = UNSUPPORTED_SEARCH_TYPE;
+      searchType = "status";
       break;
     case sbiRegEx.test(searchText):
       searchType = "sbi";
       break;
     case regexChecker(dateRegEx, searchText):
-      searchType = UNSUPPORTED_SEARCH_TYPE;
+      searchType = "date";
       break;
     case isValidSpecies:
       searchType = "species";

--- a/app/routes/models/application-list.js
+++ b/app/routes/models/application-list.js
@@ -6,9 +6,11 @@ import { getStyleClassByStatus } from "../../constants/status.js";
 import { upperFirstLetter } from "../../lib/display-helper.js";
 import { FLAG_EMOJI } from "../utils/ui-constants.js";
 import { config } from "../../config/index.js";
-import { UNSUPPORTED_SEARCH_TYPE } from "../../lib/search-validation.js";
 
 const { serviceUri } = config;
+
+// date and status are retired from agreements basic search; recognise them and return no results
+const RETIRED_SEARCH_TYPES = ["date", "status"];
 
 const emptyModel = (searchText) => ({
   applications: [],
@@ -135,7 +137,7 @@ export async function createModel(request, page) {
   const searchText = getAppSearch(request, sessionKeys.appSearch.searchText);
   const searchType = getAppSearch(request, sessionKeys.appSearch.searchType);
 
-  if (searchType === UNSUPPORTED_SEARCH_TYPE) {
+  if (RETIRED_SEARCH_TYPES.includes(searchType)) {
     return emptyModel(searchText);
   }
 

--- a/test/integration/narrow/routes/models/application-list.test.js
+++ b/test/integration/narrow/routes/models/application-list.test.js
@@ -74,33 +74,36 @@ describe("Application-list createModel", () => {
     expect(result.total).toBe(9);
   });
 
-  test("createModel returns the empty state without querying the backend for an unsupported search type", async () => {
-    getApplications.mockClear();
-    const request = {
-      yar: {
-        get: jest.fn(() => ({
-          searchType: "unsupported",
-          searchText: "01/12/2024",
-        })),
-      },
-      query: {},
-      auth: {
-        isAuthenticated: true,
-        credentials: {
-          scope: [administrator],
-          account: { username: "unit-tester" },
+  test.each([
+    { searchType: "date", searchText: "01/12/2024" },
+    { searchType: "status", searchText: "agreed" },
+  ])(
+    "createModel returns the empty state without querying the backend for a retired '$searchType' search",
+    async ({ searchType, searchText }) => {
+      getApplications.mockClear();
+      const request = {
+        yar: {
+          get: jest.fn(() => ({ searchType, searchText })),
         },
-      },
-    };
+        query: {},
+        auth: {
+          isAuthenticated: true,
+          credentials: {
+            scope: [administrator],
+            account: { username: "unit-tester" },
+          },
+        },
+      };
 
-    const result = await createModel(request, 1);
+      const result = await createModel(request, 1);
 
-    expect(result).toEqual({
-      applications: [],
-      total: 0,
-      error: "No agreements found.",
-      searchText: "01/12/2024",
-    });
-    expect(getApplications).not.toHaveBeenCalled();
-  });
+      expect(result).toEqual({
+        applications: [],
+        total: 0,
+        error: "No agreements found.",
+        searchText,
+      });
+      expect(getApplications).not.toHaveBeenCalled();
+    },
+  );
 });

--- a/test/lib/search-validation.test.js
+++ b/test/lib/search-validation.test.js
@@ -11,6 +11,7 @@ describe("searchValidation", () => {
     { type: "organisation", text: "IAHW-1234" },
     { type: "organisation", text: "IAHW-ABCD-1234-EFGH" },
     { type: "sbi", text: "107279003" },
+    { type: "date", text: "01/12/2024" },
     { type: "organisation", text: "a string" },
     { type: "species", text: "sheep" },
     { type: "reset", text: "" },
@@ -19,43 +20,29 @@ describe("searchValidation", () => {
     expect(searchType).toBe(type);
     expect(searchText).toBe(text);
   });
-
-  describe("retired basic-search terms return 'unsupported'", () => {
-    test.each([
-      { text: "01/12/2024" },
-      { text: "31/12/2025" },
-      { text: "01-12-2024" },
-      { text: "01.12.2024" },
-    ])("a date ($text) is no longer a searchable term", ({ text }) => {
-      const { searchText, searchType } = searchValidation(text);
-      expect(searchType).toBe("unsupported");
-      expect(searchText).toBe(text);
-    });
-
-    test.each([
-      { status: "agreed" },
-      { status: "applied" },
-      { status: "withdrawn" },
-      { status: "inputted" },
-      { status: "claimed" },
-      { status: "in check" },
-      { status: "check" },
-      { status: "recommended" },
-      { status: "pay" },
-      { status: "recommended to pay" },
-      { status: "reject" },
-      { status: "recommended to reject" },
-      { status: "paid" },
-      { status: "rejected" },
-      { status: "not agreed" },
-      { status: "ready" },
-      { status: "ready to pay" },
-      { status: "hold" },
-      { status: "on hold" },
-    ])("a status ($status) is no longer a searchable term", ({ status }) => {
-      const { searchText, searchType } = searchValidation(status);
-      expect(searchType).toBe("unsupported");
-      expect(searchText).toBe(status);
-    });
+  test.each([
+    { status: "agreed" },
+    { status: "applied" },
+    { status: "withdrawn" },
+    { status: "inputted" },
+    { status: "claimed" },
+    { status: "in check" },
+    { status: "check" },
+    { status: "recommended" },
+    { status: "pay" },
+    { status: "recommended to pay" },
+    { status: "reject" },
+    { status: "recommended to reject" },
+    { status: "paid" },
+    { status: "rejected" },
+    { status: "not agreed" },
+    { status: "ready" },
+    { status: "ready to pay" },
+    { status: "hold" },
+    { status: "on hold" },
+  ])("A valid status ($status) should return $status and status as type", ({ status }) => {
+    const { searchText, searchType } = searchValidation(status);
+    expect(searchType).toBe("status");
+    expect(searchText).toBe(status);
   });
 });


### PR DESCRIPTION
## Summary
Follow-up fix to the basic-search rationalisation.

Retiring date and status as search terms was only intended for the Agreements tab, but it was implemented in the search classifier that both the Agreements and Claims tabs share - so it silently disabled date and status search on the Claims tab too.

This confines the retirement to the Agreements tab and restores Claims search to its previous behaviour.

## What Changed
- Reverted the shared search classifier so it again recognises date and status terms.
- Moved the retirement of date and status search into the Agreements view model, so only the Agreements tab returns no results for those terms.
- Updated the affected unit tests.

## Why
The original change edited shared code to apply an Agreements-only rule, which broke Claims search as a side-effect and surfaced as failures in the main pipeline. Scoping the rule to the Agreements tab fixes the regression while preserving the intended Agreements behaviour. Note: the Agreements date/status journey tests in the ui-tests repo still need updating separately to expect "no results".