### PR TITLE
feat(claims): (AHWR-2048) limit basic search to claim number and SBI

### DIFF
--- a/app/routes/claims.js
+++ b/app/routes/claims.js
@@ -16,6 +16,9 @@ const { claimSearch } = sessionKeys;
 const viewTemplate = "claims";
 const currentPath = `/${viewTemplate}`;
 
+// claims basic search supports claim number and SBI only; every other term returns no results
+const SUPPORTED_SEARCH_TYPES = ["ref", "sbi", "reset"];
+
 const getViewData = async (request) => {
   const { page } = request.query;
   const returnPage = viewTemplate;
@@ -23,6 +26,22 @@ const getViewData = async (request) => {
   const searchText = getClaimSearch(request, claimSearch.searchText);
   const sort = getClaimSearch(request, claimSearch.sort);
   const { searchType, searchText: validatedSearchText } = searchValidation(searchText);
+  const header = getClaimTableHeader(sort);
+
+  if (!SUPPORTED_SEARCH_TYPES.includes(searchType)) {
+    const { previous, next, pages } = getPagingData(0, limit, request.query);
+    return {
+      searchText,
+      header,
+      rows: [],
+      previous,
+      next,
+      pages,
+      error: "No claims found.",
+      total: 0,
+    };
+  }
+
   const filter = undefined;
   const { claims, total } = await getClaims(
     searchType,
@@ -33,7 +52,6 @@ const getViewData = async (request) => {
     sort,
     request.logger,
   );
-  const header = getClaimTableHeader(sort);
   const rows = getClaimTableRows(claims, page, returnPage);
   const { previous, next, pages } = getPagingData(total, limit, request.query);
   const error = total === 0 ? "No claims found." : null;

--- a/app/routes/claims.js
+++ b/app/routes/claims.js
@@ -17,7 +17,7 @@ const viewTemplate = "claims";
 const currentPath = `/${viewTemplate}`;
 
 // claims basic search supports claim number and SBI only; every other term returns no results
-const SUPPORTED_SEARCH_TYPES = ["ref", "sbi", "reset"];
+const SUPPORTED_SEARCH_TYPES = new Set(["ref", "sbi", "reset"]);
 
 const getViewData = async (request) => {
   const { page } = request.query;
@@ -28,18 +28,17 @@ const getViewData = async (request) => {
   const { searchType, searchText: validatedSearchText } = searchValidation(searchText);
   const header = getClaimTableHeader(sort);
 
-  if (!SUPPORTED_SEARCH_TYPES.includes(searchType)) {
-    const { previous, next, pages } = getPagingData(0, limit, request.query);
-    return {
-      searchText,
-      header,
-      rows: [],
-      previous,
-      next,
-      pages,
-      error: "No claims found.",
-      total: 0,
-    };
+  const emptyViewData = () => ({
+    searchText,
+    header,
+    rows: [],
+    ...getPagingData(0, limit, request.query),
+    error: "No claims found.",
+    total: 0,
+  });
+
+  if (!SUPPORTED_SEARCH_TYPES.has(searchType)) {
+    return emptyViewData();
   }
 
   const filter = undefined;
@@ -52,20 +51,14 @@ const getViewData = async (request) => {
     sort,
     request.logger,
   );
+
+  if (total === 0) {
+    return emptyViewData();
+  }
+
   const rows = getClaimTableRows(claims, page, returnPage);
   const { previous, next, pages } = getPagingData(total, limit, request.query);
-  const error = total === 0 ? "No claims found." : null;
-
-  return {
-    searchText,
-    header,
-    rows,
-    previous,
-    next,
-    pages,
-    error,
-    total,
-  };
+  return { searchText, header, rows, previous, next, pages, error: null, total };
 };
 
 export const claimsRoutes = [

--- a/app/views/claims.njk
+++ b/app/views/claims.njk
@@ -32,8 +32,7 @@
                     <h1 class="govuk-heading-l">Claims</h1>
                     <div class="user-search-box">
                       <label class="govuk-label govuk-label--s" for="searchText">Find a claim</label>
-                      <div id="claimSearch-hint" class="govuk-hint">Search by claim number, species (e.g beef cattle), SBI, claim date or
-                        status.</div>
+                      <div id="claimSearch-hint" class="govuk-hint">Search by claim number or SBI.</div>
                       <input type="hidden" name="crumb" value="{{ crumb }}"/>
                       <input class="govuk-input" id="searchText" name="searchText" type="text" value="{{ searchText }}" spellcheck="false">
                       <button class="search-button" data-module="govuk-button" name="submit" value="search">
@@ -43,7 +42,7 @@
                   </div>
                   {% if error %}
                     <div class="govuk-grid-column-full">
-                      <p class="govuk-error-message">{{ error }}</p>
+                      <p class="govuk-body no-results-message">{{ error }}</p>
                     </div>
                   {% endif %}
                   <div class="govuk-grid-column-full">

--- a/test/integration/narrow/routes/claims.test.js
+++ b/test/integration/narrow/routes/claims.test.js
@@ -208,6 +208,7 @@ describe("Claims tests", () => {
       getClaims.mockReturnValueOnce({ claims, total: 9 });
       const res = await search("");
       expect(res.statusCode).toBe(StatusCodes.OK);
+      expect(await axe(res.payload)).toHaveNoViolations();
       expect(getClaims).toHaveBeenCalledWith(
         "reset",
         "",

--- a/test/integration/narrow/routes/claims.test.js
+++ b/test/integration/narrow/routes/claims.test.js
@@ -127,4 +127,88 @@ describe("Claims tests", () => {
       expect(setClaimSearch).toHaveBeenCalledTimes(1);
     });
   });
+
+  describe("Basic search term rationalisation", () => {
+    const search = async (searchText) => {
+      getClaimSearch.mockReturnValueOnce(searchText);
+      return server.inject({ method: "GET", url: `${url}?page=1`, auth });
+    };
+
+    beforeEach(() => {
+      jest.clearAllMocks();
+    });
+
+    test("hint tells the user only claim number or SBI are searchable", async () => {
+      const res = await search("");
+      const $ = cheerio.load(res.payload);
+      expect($("#claimSearch-hint").text().replace(/\s+/g, " ").trim()).toEqual(
+        "Search by claim number or SBI.",
+      );
+    });
+
+    test.each([
+      { searchText: "REBC-A1B2-C3D4", type: "ref" }, // claim number
+      { searchText: "107279003", type: "sbi" }, // SBI
+    ])(
+      "supported search ($searchText) queries the backend and shows results",
+      async ({ searchText, type }) => {
+        getClaims.mockReturnValueOnce({ claims, total: 3 });
+        const res = await search(searchText);
+        expect(res.statusCode).toBe(StatusCodes.OK);
+        expect(getClaims).toHaveBeenCalledWith(
+          type,
+          searchText,
+          undefined,
+          10,
+          0,
+          undefined,
+          expect.anything(),
+        );
+        const $ = cheerio.load(res.payload);
+        expect($("p.govuk-body.govuk-\\!-font-weight-bold").text()).toEqual("3 search results");
+        expect($("p.no-results-message")).toHaveLength(0);
+      },
+    );
+
+    test.each([
+      { searchText: "Beef cattle" }, // species
+      { searchText: "Dairy cattle" }, // species
+      { searchText: "Pigs" }, // species
+      { searchText: "Sheep" }, // species
+      { searchText: "Poultry" }, // species (falls through to organisation)
+      { searchText: "01/12/2024" }, // claim date
+      { searchText: "on hold" }, // claim status
+      { searchText: "Foxes Drove Farm" }, // organisation / free text
+    ])(
+      "retired search ($searchText) returns no claims without querying the backend",
+      async ({ searchText }) => {
+        const res = await search(searchText);
+        expect(res.statusCode).toBe(StatusCodes.OK);
+        expect(await axe(res.payload)).toHaveNoViolations();
+        expect(getClaims).not.toHaveBeenCalled();
+        const $ = cheerio.load(res.payload);
+        expect($("p.no-results-message").text()).toMatch("No claims found.");
+        expect($("p.govuk-error-message")).toHaveLength(0);
+        expect($("p.govuk-body.govuk-\\!-font-weight-bold").text()).toEqual("0 search results");
+      },
+    );
+
+    test("empty search shows all claims (default state)", async () => {
+      getClaims.mockReturnValueOnce({ claims, total: 9 });
+      const res = await search("");
+      expect(res.statusCode).toBe(StatusCodes.OK);
+      expect(getClaims).toHaveBeenCalledWith(
+        "reset",
+        "",
+        undefined,
+        10,
+        0,
+        undefined,
+        expect.anything(),
+      );
+      const $ = cheerio.load(res.payload);
+      expect($("p.govuk-body.govuk-\\!-font-weight-bold").text()).toEqual("9 search results");
+      expect($("p.no-results-message")).toHaveLength(0);
+    });
+  });
 });

--- a/test/integration/narrow/routes/claims.test.js
+++ b/test/integration/narrow/routes/claims.test.js
@@ -170,6 +170,17 @@ describe("Claims tests", () => {
       },
     );
 
+    test("supported search with no match shows the no-results state", async () => {
+      getClaims.mockReturnValueOnce({ claims: [], total: 0 });
+      const res = await search("107279003");
+      expect(res.statusCode).toBe(StatusCodes.OK);
+      expect(getClaims).toHaveBeenCalled();
+      const $ = cheerio.load(res.payload);
+      expect($("p.no-results-message").text()).toMatch("No claims found.");
+      expect($("p.govuk-error-message")).toHaveLength(0);
+      expect($("p.govuk-body.govuk-\\!-font-weight-bold").text()).toEqual("0 search results");
+    });
+
     test.each([
       { searchText: "Beef cattle" }, // species
       { searchText: "Dairy cattle" }, // species


### PR DESCRIPTION
## Summary
Rationalises the Basic Search on the Claims tab so it only accepts a claim number or an SBI, in line with the new search designs. Any other term now returns a clean "No claims found." empty state instead of an unpredictable result. Mirrors the equivalent change already delivered for the Agreements tab.

## What Changed
- Claims search now honours claim number and SBI only. Species, claim date, claim status, and any free-text or organisation input return zero results without querying the backend.
- An empty search still shows all claims (the default landing state), unchanged.
- The result counter reflects the search accurately, showing "0 search results" for retired terms.
- Updated the search hint copy to "Search by claim number or SBI."
- Recoloured the no-results message to the GOV.UK secondary-text colour instead of error red.
- Added integration tests covering supported terms, every retired term (including species, date, status, "Poultry" and free text), and the default empty state, with accessibility assertions on the empty state.

## Why
The previous search accepted terms the new design retires, and passed unrecognised terms straight to the backend with undefined behaviour. Restricting to the two supported terms at the UI boundary guarantees a predictable, zero-result empty state regardless of how the backend handles an unknown search type, and aligns the Claims tab with the Agreements tab. The shared search classifier is left untouched, so the Agreements tab is unaffected.

## Screenshot
<img width="1101" height="663" alt="Screenshot 2026-07-13 at 16 00 40" src="https://github.com/user-attachments/assets/bebd00d0-21e6-4164-88c4-60f5f6e314f9" />
