### PR TITLE
feat(claims): (AHWR-2053) add advanced search agreement type filter

### DIFF
--- a/app/api/claims.js
+++ b/app/api/claims.js
@@ -1,6 +1,7 @@
 import wreck from "@hapi/wreck";
 import { config } from "../config/index.js";
 import { metricsCounter } from "../lib/metrics.js";
+import { AGREEMENT_TYPE } from "../constants/index.js";
 
 const { applicationApiUri, apiKeys } = config;
 
@@ -18,7 +19,9 @@ export async function getClaim(reference, logger) {
   }
 }
 
-export async function getClaims(searchType, searchText, filter, limit, offset, sort, logger) {
+export async function getClaims(searchParameters, limit, offset, sort, logger) {
+  const { searchText, searchType, filter, agreementType } = searchParameters;
+  const hasAgreementType = agreementType && agreementType !== AGREEMENT_TYPE.ALL;
   const endpoint = `${applicationApiUri}/claims/search`;
   const options = {
     payload: {
@@ -26,6 +29,7 @@ export async function getClaims(searchType, searchText, filter, limit, offset, s
       filter,
       limit,
       offset,
+      ...(hasAgreementType && { agreementType }),
       sort,
     },
     json: true,

--- a/app/routes/agreement.js
+++ b/app/routes/agreement.js
@@ -91,9 +91,7 @@ const buildAgreementClaimsTable = async (request, applicationReference, page) =>
   const limit = 30;
   const offset = 0;
   const { claims, total } = await getClaims(
-    "appRef",
-    applicationReference,
-    undefined,
+    { searchType: "appRef", searchText: applicationReference },
     limit,
     offset,
     sortField,

--- a/app/routes/claims.js
+++ b/app/routes/claims.js
@@ -7,7 +7,9 @@ import { getClaims } from "../api/claims.js";
 import { getPagination, getPagingData } from "../pagination.js";
 import { searchValidation } from "../lib/search-validation.js";
 import { getClaimTableHeader, getClaimTableRows } from "./models/claim-list.js";
+import { getAgreementTypeOptions } from "./utils/get-agreement-type-options.js";
 import { permissions } from "../auth/permissions.js";
+import { AGREEMENT_TYPE } from "../constants/index.js";
 import { StatusCodes } from "http-status-codes";
 
 const { administrator, authoriser, processor, recommender, user } = permissions;
@@ -25,8 +27,10 @@ const getViewData = async (request) => {
   const { limit, offset } = getPagination(page);
   const searchText = getClaimSearch(request, claimSearch.searchText);
   const sort = getClaimSearch(request, claimSearch.sort);
+  const agreementType = getClaimSearch(request, claimSearch.agreementType) ?? AGREEMENT_TYPE.ALL;
   const { searchType, searchText: validatedSearchText } = searchValidation(searchText);
   const header = getClaimTableHeader(sort);
+  const agreementTypeOptions = getAgreementTypeOptions(agreementType);
 
   const emptyViewData = () => ({
     searchText,
@@ -35,17 +39,15 @@ const getViewData = async (request) => {
     ...getPagingData(0, limit, request.query),
     error: "No claims found.",
     total: 0,
+    agreementTypeOptions,
   });
 
   if (!SUPPORTED_SEARCH_TYPES.has(searchType)) {
     return emptyViewData();
   }
 
-  const filter = undefined;
   const { claims, total } = await getClaims(
-    searchType,
-    validatedSearchText,
-    filter,
+    { searchText: validatedSearchText, searchType, agreementType },
     limit,
     offset,
     sort,
@@ -58,7 +60,18 @@ const getViewData = async (request) => {
 
   const rows = getClaimTableRows(claims, page, returnPage);
   const { previous, next, pages } = getPagingData(total, limit, request.query);
-  return { searchText, header, rows, previous, next, pages, error: null, total };
+
+  return {
+    searchText,
+    header,
+    rows,
+    previous,
+    next,
+    pages,
+    error: null,
+    total,
+    agreementTypeOptions,
+  };
 };
 
 export const claimsRoutes = [
@@ -108,6 +121,33 @@ export const claimsRoutes = [
     },
   },
   {
+    method: "GET",
+    path: `${currentPath}/clear`,
+    options: {
+      auth: {
+        scope: [administrator, authoriser, processor, recommender, user],
+      },
+      validate: {
+        query: joi.object({
+          page: joi.number().greater(0).default(1),
+          limit: joi.number().greater(0).default(displayPageSize),
+        }),
+      },
+      handler: async (request, h) => {
+        try {
+          await generateNewCrumb(request, h);
+          setClaimSearch(request, claimSearch.searchText, "");
+          setClaimSearch(request, claimSearch.agreementType, AGREEMENT_TYPE.ALL);
+          const viewData = await getViewData(request);
+          return h.view(viewTemplate, viewData);
+        } catch (err) {
+          request.logger.error({ err });
+          throw err;
+        }
+      },
+    },
+  },
+  {
     method: "POST",
     path: `${currentPath}`,
     options: {
@@ -122,7 +162,13 @@ export const claimsRoutes = [
       },
       handler: async (request, h) => {
         try {
-          setClaimSearch(request, claimSearch.searchText, request.payload?.searchText);
+          const isAdvancedSearch = request.payload?.submit === "advancedSearch";
+          const agreementType = isAdvancedSearch
+            ? (request.payload?.agreementType ?? AGREEMENT_TYPE.ALL)
+            : AGREEMENT_TYPE.ALL;
+          setClaimSearch(request, claimSearch.agreementType, agreementType);
+          const searchText = isAdvancedSearch ? "" : (request.payload?.searchText ?? "");
+          setClaimSearch(request, claimSearch.searchText, searchText);
           const viewData = await getViewData(request);
           return h.view(viewTemplate, viewData);
         } catch (error) {

--- a/app/routes/claims.js
+++ b/app/routes/claims.js
@@ -26,9 +26,10 @@ const getViewData = async (request) => {
   const returnPage = viewTemplate;
   const { limit, offset } = getPagination(page);
   const searchText = getClaimSearch(request, claimSearch.searchText);
+  // an empty/absent stored type means no basic-search term is active; treat it as the show-all "reset" type
+  const searchType = getClaimSearch(request, claimSearch.searchType) || "reset";
   const sort = getClaimSearch(request, claimSearch.sort);
   const agreementType = getClaimSearch(request, claimSearch.agreementType) ?? AGREEMENT_TYPE.ALL;
-  const { searchType, searchText: validatedSearchText } = searchValidation(searchText);
   const header = getClaimTableHeader(sort);
   const agreementTypeOptions = getAgreementTypeOptions(agreementType);
 
@@ -47,7 +48,7 @@ const getViewData = async (request) => {
   }
 
   const { claims, total } = await getClaims(
-    { searchText: validatedSearchText, searchType, agreementType },
+    { searchText, searchType, agreementType },
     limit,
     offset,
     sort,
@@ -137,6 +138,7 @@ export const claimsRoutes = [
         try {
           await generateNewCrumb(request, h);
           setClaimSearch(request, claimSearch.searchText, "");
+          setClaimSearch(request, claimSearch.searchType, "");
           setClaimSearch(request, claimSearch.agreementType, AGREEMENT_TYPE.ALL);
           const viewData = await getViewData(request);
           return h.view(viewTemplate, viewData);
@@ -167,8 +169,13 @@ export const claimsRoutes = [
             ? (request.payload?.agreementType ?? AGREEMENT_TYPE.ALL)
             : AGREEMENT_TYPE.ALL;
           setClaimSearch(request, claimSearch.agreementType, agreementType);
-          const searchText = isAdvancedSearch ? "" : (request.payload?.searchText ?? "");
-          setClaimSearch(request, claimSearch.searchText, searchText);
+
+          const { searchText, searchType } = isAdvancedSearch
+            ? { searchText: "", searchType: "" }
+            : searchValidation(request.payload?.searchText);
+          setClaimSearch(request, claimSearch.searchText, searchText ?? "");
+          setClaimSearch(request, claimSearch.searchType, searchType ?? "");
+
           const viewData = await getViewData(request);
           return h.view(viewTemplate, viewData);
         } catch (error) {

--- a/app/routes/view-claim.js
+++ b/app/routes/view-claim.js
@@ -61,9 +61,7 @@ const loadClaimsBreakdown = async (scheme, applicationReference, logger) => {
   const limit = 30;
   const offset = 0;
   const { claims } = await getClaims(
-    "appRef",
-    applicationReference,
-    undefined,
+    { searchType: "appRef", searchText: applicationReference },
     limit,
     offset,
     undefined,

--- a/app/session/keys.js
+++ b/app/session/keys.js
@@ -10,6 +10,7 @@ export const sessionKeys = {
   },
   claimSearch: {
     searchText: "searchText",
+    searchType: "searchType",
     agreementType: "agreementType",
     sort: "sort",
   },

--- a/app/session/keys.js
+++ b/app/session/keys.js
@@ -10,6 +10,7 @@ export const sessionKeys = {
   },
   claimSearch: {
     searchText: "searchText",
+    agreementType: "agreementType",
     sort: "sort",
   },
 };

--- a/app/views/claims.njk
+++ b/app/views/claims.njk
@@ -1,4 +1,5 @@
 {% extends './layouts/layout.njk' %}
+{% from "govuk/components/select/macro.njk" import govukSelect %}
 {% block pageTitle %}
   Administration: AHWR Claims
 {% endblock %}
@@ -45,6 +46,28 @@
                       <p class="govuk-body no-results-message">{{ error }}</p>
                     </div>
                   {% endif %}
+                  <div class="govuk-grid-column-full">
+                    {% call govukDetails({
+                      summaryText: "Advanced search"
+                      }) %}
+                        {{ govukSelect({
+                          id: "agreementType",
+                          name: "agreementType",
+                          label: {
+                            text: "Agreement type"
+                          },
+                          items: agreementTypeOptions
+                        }) }}
+                        <div class="govuk-button-group">
+                          {{ govukButton({
+                            text: "Search",
+                            name: "submit",
+                            value: "advancedSearch"
+                          }) }}
+                          <a class="govuk-link" href="/claims/clear">Clear all filters</a>
+                        </div>
+                    {% endcall %}
+                  </div>
                   <div class="govuk-grid-column-full">
                     <p class="govuk-body govuk-!-font-weight-bold">{{ total }} search results</p>
                   </div>

--- a/test/integration/narrow/routes/claims.test.js
+++ b/test/integration/narrow/routes/claims.test.js
@@ -8,6 +8,7 @@ import { axe } from "../../../helpers/axe-helper.js";
 import { phaseBannerOk } from "../../../utils/phase-banner-expect.js";
 import { claims } from "../../../data/claims.js";
 import { getClaimSearch, setClaimSearch } from "../../../../app/session/index.js";
+import { AGREEMENT_TYPE } from "../../../../app/constants/index.js";
 import { StatusCodes } from "http-status-codes";
 
 jest.mock("../../../../app/session");
@@ -67,7 +68,7 @@ describe("Claims tests", () => {
       const $ = cheerio.load(res.payload);
       expect($("h1.govuk-heading-l").text()).toEqual("Claims");
       expect($("title").text()).toContain("AHWR Claims");
-      expect(getClaimSearch).toHaveBeenCalledTimes(2);
+      expect(getClaimSearch).toHaveBeenCalledTimes(3);
       phaseBannerOk($);
     });
 
@@ -94,6 +95,107 @@ describe("Claims tests", () => {
       const res = await server.inject(options);
       expect(res.statusCode).toBe(StatusCodes.OK);
       expect(setClaimSearch).toHaveBeenCalledTimes(1);
+    });
+
+    test("has an advanced search disclosure", async () => {
+      const options = {
+        method: "GET",
+        url: `${url}?page=1`,
+        auth,
+      };
+      const res = await server.inject(options);
+      const $ = cheerio.load(res.payload);
+      expect($(".govuk-details__summary-text").text()).toContain("Advanced search");
+    });
+
+    test("has a search button in the advanced search group", async () => {
+      const options = {
+        method: "GET",
+        url: `${url}?page=1`,
+        auth,
+      };
+      const res = await server.inject(options);
+      const $ = cheerio.load(res.payload);
+      expect($(".govuk-button-group button.govuk-button").text()).toContain("Search");
+    });
+
+    test("has an agreement type dropdown", async () => {
+      const options = {
+        method: "GET",
+        url: `${url}?page=1`,
+        auth,
+      };
+      const res = await server.inject(options);
+      const $ = cheerio.load(res.payload);
+      expect($('label[for="agreementType"]').text()).toContain("Agreement type");
+      expect($("select#agreementType")).toHaveLength(1);
+    });
+
+    test("agreement type dropdown has All types, IAHW and PBR options in order", async () => {
+      const options = {
+        method: "GET",
+        url: `${url}?page=1`,
+        auth,
+      };
+      const res = await server.inject(options);
+      const $ = cheerio.load(res.payload);
+      const optionTexts = $("select#agreementType option")
+        .map((_, el) => $(el).text().trim())
+        .get();
+      expect(optionTexts).toEqual(["All types", "IAHW", "PBR"]);
+    });
+
+    test("has a clear all filters link with href /claims/clear", async () => {
+      const options = {
+        method: "GET",
+        url: `${url}?page=1`,
+        auth,
+      };
+      const res = await server.inject(options);
+      const $ = cheerio.load(res.payload);
+      const clearLink = $(".govuk-button-group a.govuk-link");
+      expect(clearLink.text()).toContain("Clear all filters");
+      expect(clearLink.attr("href")).toEqual("/claims/clear");
+    });
+
+    test("advanced search rendering has no accessibility violations", async () => {
+      getClaims.mockReturnValueOnce({ claims, total: 0 });
+      const options = {
+        method: "GET",
+        url: `${url}?page=1`,
+        auth,
+      };
+      const res = await server.inject(options);
+      expect(await axe(res.payload)).toHaveNoViolations();
+    });
+
+    test("clear route returns 200 and resets the advanced search session", async () => {
+      const options = {
+        method: "GET",
+        url: `${url}/clear`,
+        auth,
+      };
+      const res = await server.inject(options);
+      expect(res.statusCode).toBe(StatusCodes.OK);
+      expect(setClaimSearch).toHaveBeenCalledWith(
+        expect.anything(),
+        "agreementType",
+        AGREEMENT_TYPE.ALL,
+      );
+      expect(setClaimSearch).toHaveBeenCalledWith(expect.anything(), "searchText", "");
+    });
+
+    test("clear route surfaces an error when building the view fails", async () => {
+      getPagination.mockImplementationOnce(() => {
+        throw new Error("boom");
+      });
+      const options = {
+        method: "GET",
+        url: `${url}/clear`,
+        auth,
+      };
+      const res = await server.inject(options);
+      expect(res.statusCode).toBe(StatusCodes.INTERNAL_SERVER_ERROR);
     });
   });
 
@@ -124,7 +226,73 @@ describe("Claims tests", () => {
       };
       const res = await server.inject(options);
       expect(res.statusCode).toBe(StatusCodes.OK);
-      expect(setClaimSearch).toHaveBeenCalledTimes(1);
+      expect(setClaimSearch).toHaveBeenCalledTimes(2);
+    });
+
+    test("advanced search stores the agreement type and clears the text search", async () => {
+      getClaims.mockReturnValue({ claims, total: 0 });
+      const options = {
+        method: "POST",
+        url,
+        payload: { crumb, searchText: "107279003", agreementType: "PBR", submit: "advancedSearch" },
+        headers: { cookie: `crumb=${crumb}` },
+        auth,
+      };
+      const res = await server.inject(options);
+      expect(res.statusCode).toBe(StatusCodes.OK);
+      expect(setClaimSearch).toHaveBeenCalledWith(expect.anything(), "agreementType", "PBR");
+      expect(setClaimSearch).toHaveBeenCalledWith(expect.anything(), "searchText", "");
+    });
+
+    test("basic search stores the text and resets the agreement type", async () => {
+      getClaims.mockReturnValue({ claims, total: 0 });
+      const options = {
+        method: "POST",
+        url,
+        payload: { crumb, searchText: "107279003", agreementType: "PBR", submit: "search" },
+        headers: { cookie: `crumb=${crumb}` },
+        auth,
+      };
+      const res = await server.inject(options);
+      expect(res.statusCode).toBe(StatusCodes.OK);
+      expect(setClaimSearch).toHaveBeenCalledWith(
+        expect.anything(),
+        "agreementType",
+        AGREEMENT_TYPE.ALL,
+      );
+      expect(setClaimSearch).toHaveBeenCalledWith(expect.anything(), "searchText", "107279003");
+    });
+
+    test("advanced search without an agreement type falls back to all types", async () => {
+      getClaims.mockReturnValue({ claims, total: 0 });
+      const options = {
+        method: "POST",
+        url,
+        payload: { crumb, submit: "advancedSearch" },
+        headers: { cookie: `crumb=${crumb}` },
+        auth,
+      };
+      const res = await server.inject(options);
+      expect(res.statusCode).toBe(StatusCodes.OK);
+      expect(setClaimSearch).toHaveBeenCalledWith(
+        expect.anything(),
+        "agreementType",
+        AGREEMENT_TYPE.ALL,
+      );
+    });
+
+    test("basic search without search text falls back to an empty string", async () => {
+      getClaims.mockReturnValue({ claims, total: 0 });
+      const options = {
+        method: "POST",
+        url,
+        payload: { crumb, submit: "search" },
+        headers: { cookie: `crumb=${crumb}` },
+        auth,
+      };
+      const res = await server.inject(options);
+      expect(res.statusCode).toBe(StatusCodes.OK);
+      expect(setClaimSearch).toHaveBeenCalledWith(expect.anything(), "searchText", "");
     });
   });
 
@@ -156,9 +324,7 @@ describe("Claims tests", () => {
         const res = await search(searchText);
         expect(res.statusCode).toBe(StatusCodes.OK);
         expect(getClaims).toHaveBeenCalledWith(
-          type,
-          searchText,
-          undefined,
+          { searchText, searchType: type, agreementType: AGREEMENT_TYPE.ALL },
           10,
           0,
           undefined,
@@ -210,9 +376,7 @@ describe("Claims tests", () => {
       expect(res.statusCode).toBe(StatusCodes.OK);
       expect(await axe(res.payload)).toHaveNoViolations();
       expect(getClaims).toHaveBeenCalledWith(
-        "reset",
-        "",
-        undefined,
+        { searchText: "", searchType: "reset", agreementType: AGREEMENT_TYPE.ALL },
         10,
         0,
         undefined,

--- a/test/integration/narrow/routes/claims.test.js
+++ b/test/integration/narrow/routes/claims.test.js
@@ -68,7 +68,7 @@ describe("Claims tests", () => {
       const $ = cheerio.load(res.payload);
       expect($("h1.govuk-heading-l").text()).toEqual("Claims");
       expect($("title").text()).toContain("AHWR Claims");
-      expect(getClaimSearch).toHaveBeenCalledTimes(3);
+      expect(getClaimSearch).toHaveBeenCalledTimes(4);
       phaseBannerOk($);
     });
 
@@ -183,6 +183,7 @@ describe("Claims tests", () => {
         AGREEMENT_TYPE.ALL,
       );
       expect(setClaimSearch).toHaveBeenCalledWith(expect.anything(), "searchText", "");
+      expect(setClaimSearch).toHaveBeenCalledWith(expect.anything(), "searchType", "");
     });
 
     test("clear route surfaces an error when building the view fails", async () => {
@@ -226,7 +227,7 @@ describe("Claims tests", () => {
       };
       const res = await server.inject(options);
       expect(res.statusCode).toBe(StatusCodes.OK);
-      expect(setClaimSearch).toHaveBeenCalledTimes(2);
+      expect(setClaimSearch).toHaveBeenCalledTimes(3);
     });
 
     test("advanced search stores the agreement type and clears the text search", async () => {
@@ -242,9 +243,10 @@ describe("Claims tests", () => {
       expect(res.statusCode).toBe(StatusCodes.OK);
       expect(setClaimSearch).toHaveBeenCalledWith(expect.anything(), "agreementType", "PBR");
       expect(setClaimSearch).toHaveBeenCalledWith(expect.anything(), "searchText", "");
+      expect(setClaimSearch).toHaveBeenCalledWith(expect.anything(), "searchType", "");
     });
 
-    test("basic search stores the text and resets the agreement type", async () => {
+    test("basic search stores the text and type and resets the agreement type", async () => {
       getClaims.mockReturnValue({ claims, total: 0 });
       const options = {
         method: "POST",
@@ -261,6 +263,7 @@ describe("Claims tests", () => {
         AGREEMENT_TYPE.ALL,
       );
       expect(setClaimSearch).toHaveBeenCalledWith(expect.anything(), "searchText", "107279003");
+      expect(setClaimSearch).toHaveBeenCalledWith(expect.anything(), "searchType", "sbi");
     });
 
     test("advanced search without an agreement type falls back to all types", async () => {
@@ -293,12 +296,41 @@ describe("Claims tests", () => {
       const res = await server.inject(options);
       expect(res.statusCode).toBe(StatusCodes.OK);
       expect(setClaimSearch).toHaveBeenCalledWith(expect.anything(), "searchText", "");
+      expect(setClaimSearch).toHaveBeenCalledWith(expect.anything(), "searchType", "reset");
     });
+
+    test.each([
+      { searchText: "Beef cattle", searchType: "species" },
+      { searchText: "01/12/2024", searchType: "date" },
+      { searchText: "on hold", searchType: "status" },
+      { searchText: "Foxes Drove Farm", searchType: "organisation" },
+    ])(
+      "classifies an unsupported basic-search term ($searchText) and stores its type",
+      async ({ searchText, searchType }) => {
+        getClaims.mockReturnValue({ claims, total: 0 });
+        const options = {
+          method: "POST",
+          url,
+          payload: { crumb, searchText, submit: "search" },
+          headers: { cookie: `crumb=${crumb}` },
+          auth,
+        };
+        const res = await server.inject(options);
+        expect(res.statusCode).toBe(StatusCodes.OK);
+        expect(setClaimSearch).toHaveBeenCalledWith(expect.anything(), "searchType", searchType);
+      },
+    );
   });
 
   describe("Basic search term rationalisation", () => {
-    const search = async (searchText) => {
-      getClaimSearch.mockReturnValueOnce(searchText);
+    // The session is mocked, so a POST's stored searchType does not round-trip to getViewData;
+    // drive the stored type directly to exercise the allow-list on render.
+    const searchByType = async ({ searchText = "", searchType }) => {
+      getClaimSearch.mockImplementation((_request, key) => {
+        if (key === "searchType") return searchType;
+        if (key === "searchText") return searchText;
+        return undefined;
+      });
       return server.inject({ method: "GET", url: `${url}?page=1`, auth });
     };
 
@@ -307,7 +339,7 @@ describe("Claims tests", () => {
     });
 
     test("hint tells the user only claim number or SBI are searchable", async () => {
-      const res = await search("");
+      const res = await searchByType({ searchType: "reset" });
       const $ = cheerio.load(res.payload);
       expect($("#claimSearch-hint").text().replace(/\s+/g, " ").trim()).toEqual(
         "Search by claim number or SBI.",
@@ -315,16 +347,16 @@ describe("Claims tests", () => {
     });
 
     test.each([
-      { searchText: "REBC-A1B2-C3D4", type: "ref" }, // claim number
-      { searchText: "107279003", type: "sbi" }, // SBI
+      { searchText: "REBC-A1B2-C3D4", searchType: "ref" },
+      { searchText: "107279003", searchType: "sbi" },
     ])(
-      "supported search ($searchText) queries the backend and shows results",
-      async ({ searchText, type }) => {
+      "supported search type ($searchType) queries the backend and shows results",
+      async ({ searchText, searchType }) => {
         getClaims.mockReturnValueOnce({ claims, total: 3 });
-        const res = await search(searchText);
+        const res = await searchByType({ searchText, searchType });
         expect(res.statusCode).toBe(StatusCodes.OK);
         expect(getClaims).toHaveBeenCalledWith(
-          { searchText, searchType: type, agreementType: AGREEMENT_TYPE.ALL },
+          { searchText, searchType, agreementType: AGREEMENT_TYPE.ALL },
           10,
           0,
           undefined,
@@ -338,7 +370,7 @@ describe("Claims tests", () => {
 
     test("supported search with no match shows the no-results state", async () => {
       getClaims.mockReturnValueOnce({ claims: [], total: 0 });
-      const res = await search("107279003");
+      const res = await searchByType({ searchText: "107279003", searchType: "sbi" });
       expect(res.statusCode).toBe(StatusCodes.OK);
       expect(getClaims).toHaveBeenCalled();
       const $ = cheerio.load(res.payload);
@@ -348,18 +380,14 @@ describe("Claims tests", () => {
     });
 
     test.each([
-      { searchText: "Beef cattle" }, // species
-      { searchText: "Dairy cattle" }, // species
-      { searchText: "Pigs" }, // species
-      { searchText: "Sheep" }, // species
-      { searchText: "Poultry" }, // species (falls through to organisation)
-      { searchText: "01/12/2024" }, // claim date
-      { searchText: "on hold" }, // claim status
-      { searchText: "Foxes Drove Farm" }, // organisation / free text
+      { searchType: "species" },
+      { searchType: "date" },
+      { searchType: "status" },
+      { searchType: "organisation" },
     ])(
-      "retired search ($searchText) returns no claims without querying the backend",
-      async ({ searchText }) => {
-        const res = await search(searchText);
+      "unsupported search type ($searchType) returns no claims without querying the backend",
+      async ({ searchType }) => {
+        const res = await searchByType({ searchType });
         expect(res.statusCode).toBe(StatusCodes.OK);
         expect(await axe(res.payload)).toHaveNoViolations();
         expect(getClaims).not.toHaveBeenCalled();
@@ -370,9 +398,9 @@ describe("Claims tests", () => {
       },
     );
 
-    test("empty search shows all claims (default state)", async () => {
+    test("empty/absent search type shows all claims (default state)", async () => {
       getClaims.mockReturnValueOnce({ claims, total: 9 });
-      const res = await search("");
+      const res = await searchByType({ searchText: "", searchType: "reset" });
       expect(res.statusCode).toBe(StatusCodes.OK);
       expect(await axe(res.payload)).toHaveNoViolations();
       expect(getClaims).toHaveBeenCalledWith(

--- a/test/unit/api/claims.test.js
+++ b/test/unit/api/claims.test.js
@@ -10,12 +10,13 @@ import {
 } from "../../../app/api/claims.js";
 import { metricsCounter } from "../../../app/lib/metrics.js";
 import { config } from "../../../app/config/index.js";
+import { AGREEMENT_TYPE } from "../../../app/constants/index.js";
 
 jest.mock("@hapi/wreck");
 jest.mock("../../../app/config");
 jest.mock("../../../app/lib/metrics.js");
 
-const { apiKeys } = config;
+const { apiKeys, applicationApiUri } = config;
 
 describe("Claims API", () => {
   const applicationReference = "AHWR-1234-APP1";
@@ -63,7 +64,13 @@ describe("Claims API", () => {
   });
 
   describe("POST getClaims", () => {
-    test("returns payload if everything is ok", async () => {
+    const limit = 20;
+    const offset = 0;
+    const searchText = "12345";
+    const searchType = "sbi";
+    const endpoint = `${applicationApiUri}/claims/search`;
+
+    test("returns the payload and posts the base search payload", async () => {
       const wreckResponse = {
         payload: { claims, total: claims.length },
         res: {
@@ -74,9 +81,64 @@ describe("Claims API", () => {
 
       wreck.post = jest.fn().mockResolvedValueOnce(wreckResponse);
 
-      const response = await getClaims("sbi", "12345");
+      const response = await getClaims({ searchType, searchText }, limit, offset);
 
       expect(response).toEqual(wreckResponse.payload);
+      expect(wreck.post).toHaveBeenCalledWith(endpoint, {
+        payload: {
+          search: { text: searchText, type: searchType },
+          filter: undefined,
+          limit,
+          offset,
+          sort: undefined,
+        },
+        json: true,
+        headers: { "x-api-key": apiKeys.backofficeUiApiKey },
+      });
+    });
+
+    test("includes agreementType in the payload when a specific type is given", async () => {
+      const sort = "ASC";
+      wreck.post = jest.fn().mockResolvedValueOnce({ payload: { claims: [], total: 0 } });
+
+      await getClaims({ searchType, searchText, agreementType: "PBR" }, limit, offset, sort);
+
+      expect(wreck.post).toHaveBeenCalledWith(endpoint, {
+        payload: {
+          search: { text: searchText, type: searchType },
+          filter: undefined,
+          limit,
+          offset,
+          agreementType: "PBR",
+          sort,
+        },
+        json: true,
+        headers: { "x-api-key": apiKeys.backofficeUiApiKey },
+      });
+    });
+
+    test("omits agreementType from the payload when the type is all", async () => {
+      const sort = "ASC";
+      wreck.post = jest.fn().mockResolvedValueOnce({ payload: { claims: [], total: 0 } });
+
+      await getClaims(
+        { searchType, searchText, agreementType: AGREEMENT_TYPE.ALL },
+        limit,
+        offset,
+        sort,
+      );
+
+      expect(wreck.post).toHaveBeenCalledWith(endpoint, {
+        payload: {
+          search: { text: searchText, type: searchType },
+          filter: undefined,
+          limit,
+          offset,
+          sort,
+        },
+        json: true,
+        headers: { "x-api-key": apiKeys.backofficeUiApiKey },
+      });
     });
 
     test("throws error if error returned", async () => {
@@ -92,7 +154,7 @@ describe("Claims API", () => {
       const logger = { error: jest.fn() };
       const filter = { field: "updatedAt", op: "lte", value: "2025-01-17" };
       await expect(async () => {
-        await getClaims("sbi", "1010", filter, 10, 10, "ASC", logger);
+        await getClaims({ searchType: "sbi", searchText: "1010", filter }, 10, 10, "ASC", logger);
       }).rejects.toEqual(wreckResponse);
     });
   });


### PR DESCRIPTION
## Summary
Adds the Advanced Search framework and its first filter, Agreement type (IAHW / PBR / All types), to the Claims tab.

This mirrors the framework already delivered for the Agreements tab, adapted to the Claims view, and feeds the existing result counter.

## What Changed
- Added an Advanced Search disclosure on the Claims tab containing an Agreement type dropdown, a Search button, and a Clear all filters link.
- Basic Search and Advanced Search are mutually exclusive: running one resets the other, so the two never combine.
- Added a route to clear all filters, resetting the agreement type and search text back to their defaults.
- The claims API call now sends the selected agreement type to the backend (omitted when All types is selected).
- Refactored the claims API helper to take a single search parameters object, updating its other call sites to match.
- Aligned search-state handling with the Agreements tab: the classified search type is now persisted in the session alongside the search text, rather than recomputed on each render.

## Why
Back office staff need to narrow the claims list by scheme without leaning on the free text search. The agreement type is resolved to a set of reference prefixes by the application backend, keeping the UI thin. The framework is built to match the Agreements tab so both tabs behave identically and later Claims filters (date, status, flag, species, claim type) can slot into the same structure.

## Screenshot
<img width="1125" height="1098" alt="Screenshot 2026-07-16 at 16 10 46" src="https://github.com/user-attachments/assets/28047069-5cc0-4e9a-bd76-684efb3c1a8b" />
