### PR TITLE
fix(claims): (AHWR-2124) make sort column links absolute #patch

### DIFF
--- a/app/routes/models/claim-list.js
+++ b/app/routes/models/claim-list.js
@@ -13,7 +13,7 @@ const { serviceUri } = config;
 const respText = "responsive-text";
 const col6RespText = `col-6 ${respText}`;
 
-export const getClaimTableHeader = (sortField, dataURLPrefix = "", showSBI = true) => {
+export const getClaimTableHeader = (sortField, dataURLPrefix = "/", showSBI = true) => {
   const direction = sortField?.direction === "DESC" ? "descending" : "ascending";
   const sort = sortField ? sortField.field : "";
 
@@ -34,7 +34,7 @@ export const getClaimTableHeader = (sortField, dataURLPrefix = "", showSBI = tru
       text: "Species",
       attributes: {
         "aria-sort": sort === "species" ? direction : "none",
-        "data-url": "claims/sort/species",
+        "data-url": `${dataURLPrefix}claims/sort/species`,
       },
       classes: col6RespText,
     },
@@ -50,7 +50,7 @@ export const getClaimTableHeader = (sortField, dataURLPrefix = "", showSBI = tru
       text: "SBI number",
       attributes: {
         "aria-sort": sort === "SBI" ? direction : "none",
-        "data-url": "/claims/sort/SBI",
+        "data-url": `${dataURLPrefix}claims/sort/SBI`,
       },
       format: "numeric",
       classes: `col-6 align-left ${respText}`,
@@ -59,7 +59,7 @@ export const getClaimTableHeader = (sortField, dataURLPrefix = "", showSBI = tru
       text: "Claim date",
       attributes: {
         "aria-sort": sort === "claim date" ? direction : "none",
-        "data-url": "claims/sort/claim date",
+        "data-url": `${dataURLPrefix}claims/sort/claim date`,
       },
       format: "date",
       classes: `col-6 align-left ${respText}`,
@@ -68,7 +68,7 @@ export const getClaimTableHeader = (sortField, dataURLPrefix = "", showSBI = tru
       text: "Status",
       attributes: {
         "aria-sort": sort === "status" ? direction : "none",
-        "data-url": "claims/sort/status",
+        "data-url": `${dataURLPrefix}claims/sort/status`,
       },
       classes: col6RespText,
     },

--- a/app/routes/models/claim-list.test.js
+++ b/app/routes/models/claim-list.test.js
@@ -16,6 +16,33 @@ describe("getClaimTableHeader", () => {
     const header = getClaimTableHeader(null);
     expect(header[4].text).toBe("Herd/Site CPH");
   });
+
+  const sortUrlsOf = (header) =>
+    header
+      .filter((column) => column.attributes?.["data-url"])
+      .map((column) => column.attributes["data-url"]);
+
+  // Relative sort links resolve against whatever path the browser is on, so they break on any
+  // route deeper than /claims (e.g. /claims/clear). Absolute links are immune.
+  test("builds absolute sort links when rendered on the claims tab", () => {
+    expect(sortUrlsOf(getClaimTableHeader(null))).toEqual([
+      "/claims/sort/claim number",
+      "/claims/sort/species",
+      "/claims/sort/SBI",
+      "/claims/sort/claim date",
+      "/claims/sort/status",
+    ]);
+  });
+
+  test("builds prefixed sort links when rendered under an agreement", () => {
+    expect(sortUrlsOf(getClaimTableHeader(null, "/agreement/IAHW-1234-5678/"))).toEqual([
+      "/agreement/IAHW-1234-5678/claims/sort/claim number",
+      "/agreement/IAHW-1234-5678/claims/sort/species",
+      "/agreement/IAHW-1234-5678/claims/sort/SBI",
+      "/agreement/IAHW-1234-5678/claims/sort/claim date",
+      "/agreement/IAHW-1234-5678/claims/sort/status",
+    ]);
+  });
 });
 
 describe("Application-list model test", () => {


### PR DESCRIPTION
## Summary
Fixes column sorting on the Claims tab silently failing after using "Clear all filters".

Four of the five sort links were built as relative URLs, which resolve against whatever path the browser is currently on, so they broke on any route deeper than the claims list. SBI was the only column unaffected, because it was the one link already written as an absolute path.

## What Changed
- All five claim sort links are now absolute, built from the existing data URL prefix rather than hardcoded strings.
- The prefix now defaults to a leading slash, so the Claims tab produces absolute links while the agreement detail page keeps its own correctly prefixed links to its separate sort route.
- Added unit tests asserting the exact links produced for both callers.

## Why
This is a pre-existing defect that dates back to the original code import, not a regression from recent work - it was simply unreachable until a route was added that renders the claims list at a deeper path, which is what exposed it. The fix is small and low risk, but it sits directly in the critical path of the Claims Advanced Search work, so it is worth landing before that ships rather than as a fast follow.