### PR TITLE
feat: (ahwr-2136) agreement type text

### DIFF
--- a/app/routes/utils/get-agreement-type-options.js
+++ b/app/routes/utils/get-agreement-type-options.js
@@ -2,8 +2,8 @@ import { AGREEMENT_TYPE, AGREEMENT_STATUS, FLAG } from "../../constants/index.js
 
 const agreementTypeLabels = {
   [AGREEMENT_TYPE.ALL]: "All types",
-  [AGREEMENT_TYPE.IAHW]: "IAHW",
-  [AGREEMENT_TYPE.PBR]: "PBR",
+  [AGREEMENT_TYPE.IAHW]: "Improve Animal Health and Welfare (IAHW)",
+  [AGREEMENT_TYPE.PBR]: "Poultry Biosecurity Review (PBR)",
 };
 
 const statusLabels = {

--- a/app/views/agreements.njk
+++ b/app/views/agreements.njk
@@ -54,7 +54,8 @@
                           id: "agreementType",
                           name: "agreementType",
                           label: {
-                            text: "Agreement type"
+                            text: "Agreement type",
+                            classes: "govuk-label--s"
                           },
                           items: model.agreementTypeOptions
                         }) }}
@@ -88,7 +89,8 @@
                             id: "flag",
                             name: "flag",
                             label: {
-                              text: "Flag"
+                              text: "Flag",
+                              classes: "govuk-label--s"
                             },
                             items: model.flagOptions
                           }) }}
@@ -97,7 +99,8 @@
                             id: "status",
                             name: "status",
                             label: {
-                              text: "Status"
+                              text: "Status",
+                              classes: "govuk-label--s"
                             },
                             items: model.statusOptions
                           }) }}

--- a/app/views/claims.njk
+++ b/app/views/claims.njk
@@ -54,7 +54,8 @@
                           id: "agreementType",
                           name: "agreementType",
                           label: {
-                            text: "Agreement type"
+                            text: "Agreement type",
+                            classes: "govuk-label--s"
                           },
                           items: agreementTypeOptions
                         }) }}
@@ -89,7 +90,8 @@
                             id: "claimType",
                             name: "claimType",
                             label: {
-                              text: "Claim type"
+                              text: "Claim type",
+                              classes: "govuk-label--s"
                             },
                             items: claimTypeOptions
                           }) }}
@@ -98,7 +100,8 @@
                             id: "species",
                             name: "species",
                             label: {
-                              text: "Species"
+                              text: "Species",
+                              classes: "govuk-label--s"
                             },
                             items: speciesOptions
                           }) }}
@@ -107,7 +110,8 @@
                             id: "flag",
                             name: "flag",
                             label: {
-                              text: "Flag"
+                              text: "Flag",
+                              classes: "govuk-label--s"
                             },
                             items: flagOptions
                           }) }}
@@ -116,7 +120,8 @@
                             id: "status",
                             name: "status",
                             label: {
-                              text: "Status"
+                              text: "Status",
+                              classes: "govuk-label--s"
                             },
                             items: statusOptions
                           }) }}

--- a/test/integration/narrow/routes/agreements.test.js
+++ b/test/integration/narrow/routes/agreements.test.js
@@ -164,7 +164,11 @@ describe("Applications test", () => {
         const optionTexts = $("select#agreementType option")
           .map((_, el) => $(el).text().trim())
           .get();
-        expect(optionTexts).toEqual(["All types", "IAHW", "PBR"]);
+        expect(optionTexts).toEqual([
+          "All types",
+          "Improve Animal Health and Welfare (IAHW)",
+          "Poultry Biosecurity Review (PBR)",
+        ]);
       });
 
       test("has a flag dropdown", async () => {

--- a/test/integration/narrow/routes/claims.test.js
+++ b/test/integration/narrow/routes/claims.test.js
@@ -148,7 +148,11 @@ describe("Claims tests", () => {
       const optionTexts = $("select#agreementType option")
         .map((_, el) => $(el).text().trim())
         .get();
-      expect(optionTexts).toEqual(["All types", "IAHW", "PBR"]);
+      expect(optionTexts).toEqual([
+        "All types",
+        "Improve Animal Health and Welfare (IAHW)",
+        "Poultry Biosecurity Review (PBR)",
+      ]);
     });
 
     test("claim type dropdown has All types, Review and Endemics options in order", async () => {

--- a/test/unit/routes/utils/get-agreement-type-options.test.js
+++ b/test/unit/routes/utils/get-agreement-type-options.test.js
@@ -11,8 +11,16 @@ describe("getAgreementTypeOptions", () => {
 
     expect(options).toEqual([
       { value: AGREEMENT_TYPE.ALL, text: "All types", selected: true },
-      { value: AGREEMENT_TYPE.IAHW, text: "IAHW", selected: false },
-      { value: AGREEMENT_TYPE.PBR, text: "PBR", selected: false },
+      {
+        value: AGREEMENT_TYPE.IAHW,
+        text: "Improve Animal Health and Welfare (IAHW)",
+        selected: false,
+      },
+      {
+        value: AGREEMENT_TYPE.PBR,
+        text: "Poultry Biosecurity Review (PBR)",
+        selected: false,
+      },
     ]);
   });
 
@@ -21,7 +29,7 @@ describe("getAgreementTypeOptions", () => {
 
     expect(options.find((option) => option.selected)).toEqual({
       value: AGREEMENT_TYPE.IAHW,
-      text: "IAHW",
+      text: "Improve Animal Health and Welfare (IAHW)",
       selected: true,
     });
   });


### PR DESCRIPTION
Changing the text displayed on the dropdown for the agreement type advance search. Also, boldened all titles for advance search options as per mock-ups (only agreement date from and agreement date to were boldened)