### PR TITLE
refactor(auth): (AHWR-2169) remove legacy credential logic and feature flag #patch

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,10 @@ up the data for the frontend.
 When running locally there is a dev auth mode, which will allow you inside without needing to authenticate with Azure AD.
 To disable this, set the environment variable `AADAR_ENABLED` to `true` in your local `.env` file.
 
+Note that real Azure AD authentication only works when the service is running on CDP. The client assertion is an AWS
+STS Web Identity token obtained from the ECS task role, which is not available outside that environment, so dev auth
+is the only way to sign in locally.
+
 The dev auth will pick a random username by default, but this can be overridden by
 navigating to `service/login?userId=<yourchosenuser>`.
 You can choose to login as a user with a specific role by setting the userId to the name of the role,

--- a/app/auth/azure-auth.js
+++ b/app/auth/azure-auth.js
@@ -37,23 +37,15 @@ const msalLogging = getMsalLoggingSetup();
 let msalApplication;
 
 export const init = () => {
-  let auth;
+  // Bug in library where audience should be an array but expected type is string
+  const authProvider = new WebIdentityTokenProvider({ audience: ["ahwr-backoffice-ui"] });
 
-  if (config.federatedCredentials.enabled) {
-    // Bug in library where audience should be an array but expected type is string
-    const authProvider = new WebIdentityTokenProvider({ audience: ["ahwr-backoffice-ui"] });
-
-    auth = {
+  msalApplication = new ConfidentialClientApplication({
+    auth: {
       clientId: config.auth.clientId,
       authority: config.auth.authority,
       clientAssertion: async () => authProvider.getCredentials(wrapLoggerForPino(getLogger())),
-    };
-  } else {
-    auth = config.auth;
-  }
-
-  msalApplication = new ConfidentialClientApplication({
-    auth,
+    },
     system: { loggerOptions: msalLogging, customAgentOptions: { keepAlive: false } },
   });
 };

--- a/app/config/auth.js
+++ b/app/config/auth.js
@@ -3,7 +3,6 @@ import joi from "joi";
 const buildAuthConfig = () => {
   const schema = joi.object({
     enabled: joi.boolean().required(),
-    clientSecret: joi.string().required(),
     clientId: joi.string().required(),
     authority: joi.string().uri().required(),
     redirectUrl: joi.string().uri().required(),
@@ -11,7 +10,6 @@ const buildAuthConfig = () => {
 
   const config = {
     enabled: process.env.AADAR_ENABLED === "true",
-    clientSecret: process.env.AADAR_CLIENT_SECRET,
     clientId: process.env.AADAR_CLIENT_ID,
     authority: process.env.AADAR_AUTHORITY_URL,
     redirectUrl: process.env.AADAR_REDIRECT_URL,

--- a/app/config/index.js
+++ b/app/config/index.js
@@ -54,9 +54,6 @@ const getConfigSchema = () =>
     logLevel: joi.string().required(),
     logFormat: joi.string().required(),
     logRedact: joi.array().items(joi.string()),
-    federatedCredentials: {
-      enabled: joi.bool().required(),
-    },
     withdrawClaimEnabled: joi.bool().optional().default(false),
   });
 
@@ -112,9 +109,6 @@ const buildConfig = () => {
     logRedact: process.env.LOG_REDACT
       ? process.env.LOG_REDACT.split(",")
       : ["req.headers", "res.headers"],
-    federatedCredentials: {
-      enabled: process.env.FEDERATED_CREDENTIALS_ENABLED === "true",
-    },
     withdrawClaimEnabled: process.env.WITHDRAW_CLAIM_ENABLED === "true",
   };
 

--- a/docker-compose.test.yaml
+++ b/docker-compose.test.yaml
@@ -8,10 +8,8 @@ services:
     environment:
       NODE_ENV: test
       AADAR_ENABLED: "true"
-      AADAR_CLIENT_SECRET: itsasecretshhhhhhhh
       AADAR_CLIENT_ID: NCC-1701-D
       AADAR_REDIRECT_URL: http://thesearenotthedroidsyouarelookingfor
-      AADAR_TENANT_ID: C3PO-R2D2
     image: ahwr-backoffice-ui-development
     container_name: ahwr-backoffice-ui-test
     command: npm run test

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -7,7 +7,6 @@ services:
     container_name: ahwr-backoffice-ui
     environment:
       AADAR_ENABLED: ${AADAR_ENABLED:-false}
-      AADAR_CLIENT_SECRET: ${AADAR_CLIENT_SECRET:-notset}
       AADAR_CLIENT_ID: ${AADAR_CLIENT_ID:-notset}
       AADAR_REDIRECT_URL: ${AADAR_REDIRECT_URL:-http://localhost:3002/authenticate}
       AADAR_AUTHORITY_URL: ${AADAR_AUTHORITY_URL:-http://notset}

--- a/test/unit/auth/azure-auth.test.js
+++ b/test/unit/auth/azure-auth.test.js
@@ -22,7 +22,6 @@ jest.mock("../../../app/config/index.js", () => {
     ...actual,
     config: {
       ...actual.config,
-      federatedCredentials: { enabled: false },
       auth: {
         clientId: "test-client-id",
         authority: "https://test-authority",
@@ -41,9 +40,18 @@ const mockLogger = {
 };
 
 describe("Azure auth test", () => {
+  const mockGetCredentials = jest.fn();
+
   beforeAll(() => {
     process.env.NODE_ENV = "production";
   });
+
+  beforeEach(() => {
+    getLogger.mockReturnValue(mockLogger);
+    WebIdentityTokenProvider.mockImplementation(() => ({ getCredentials: mockGetCredentials }));
+    ConfidentialClientApplication.mockImplementation(() => ({}));
+  });
+
   afterEach(() => {
     jest.clearAllMocks();
   });
@@ -78,79 +86,72 @@ describe("Azure auth test", () => {
     );
   });
 
-  describe("when federated credentials are enabled", () => {
-    const mockGetCredentials = jest.fn();
+  test("the msal application is built with no client secret", () => {
+    init();
 
-    beforeEach(() => {
-      config.federatedCredentials.enabled = true;
-      getLogger.mockReturnValue(mockLogger);
-      WebIdentityTokenProvider.mockImplementation(() => ({ getCredentials: mockGetCredentials }));
-      ConfidentialClientApplication.mockImplementation(() => ({}));
-    });
+    const { auth } = ConfidentialClientApplication.mock.calls[0][0];
 
-    afterEach(() => {
-      config.federatedCredentials.enabled = false;
-    });
+    expect(auth).not.toHaveProperty("clientSecret");
+  });
 
-    test("clientAssertion retrieves and returns credentials from the auth provider", async () => {
-      const expectedAssertion = "test-assertion-token";
-      mockGetCredentials.mockResolvedValue(expectedAssertion);
+  test("clientAssertion retrieves and returns credentials from the auth provider", async () => {
+    const expectedAssertion = "test-assertion-token";
+    mockGetCredentials.mockResolvedValue(expectedAssertion);
 
-      init();
+    init();
 
-      expect(ConfidentialClientApplication).toHaveBeenCalledWith(
-        expect.objectContaining({
-          auth: expect.objectContaining({
-            clientId: config.auth.clientId,
-            authority: config.auth.authority,
-            clientAssertion: expect.any(Function),
-          }),
+    expect(ConfidentialClientApplication).toHaveBeenCalledWith(
+      expect.objectContaining({
+        auth: expect.objectContaining({
+          clientId: config.auth.clientId,
+          authority: config.auth.authority,
+          clientAssertion: expect.any(Function),
         }),
-      );
-      expect(WebIdentityTokenProvider).toHaveBeenCalledWith({ audience: ["ahwr-backoffice-ui"] });
+      }),
+    );
+    expect(WebIdentityTokenProvider).toHaveBeenCalledWith({ audience: ["ahwr-backoffice-ui"] });
 
+    const { auth } = ConfidentialClientApplication.mock.calls[0][0];
+    const assertion = await auth.clientAssertion();
+
+    expect(mockGetCredentials).toHaveBeenCalled();
+    expect(assertion).toBe(expectedAssertion);
+  });
+
+  describe("wrapped logger passed to getCredentials", () => {
+    let wrappedLogger;
+
+    beforeEach(async () => {
+      mockGetCredentials.mockResolvedValue("token");
+      init();
       const { auth } = ConfidentialClientApplication.mock.calls[0][0];
-      const assertion = await auth.clientAssertion();
-
-      expect(mockGetCredentials).toHaveBeenCalled();
-      expect(assertion).toBe(expectedAssertion);
+      await auth.clientAssertion();
+      wrappedLogger = mockGetCredentials.mock.calls[0][0];
     });
 
-    describe("wrapped logger passed to getCredentials", () => {
-      let wrappedLogger;
+    test("does not pass the raw logger directly", () => {
+      expect(wrappedLogger).not.toBe(mockLogger);
+    });
 
-      beforeEach(async () => {
-        mockGetCredentials.mockResolvedValue("token");
-        init();
-        const { auth } = ConfidentialClientApplication.mock.calls[0][0];
-        await auth.clientAssertion();
-        wrappedLogger = mockGetCredentials.mock.calls[0][0];
-      });
+    test("passes info calls through to the underlying logger", () => {
+      wrappedLogger.info("test info");
+      expect(mockLogger.info).toHaveBeenCalledWith("test info");
+    });
 
-      test("does not pass the raw logger directly", () => {
-        expect(wrappedLogger).not.toBe(mockLogger);
-      });
+    test("passes warn calls through to the underlying logger", () => {
+      wrappedLogger.warn("test warning");
+      expect(mockLogger.warn).toHaveBeenCalledWith("test warning");
+    });
 
-      test("passes info calls through to the underlying logger", () => {
-        wrappedLogger.info("test info");
-        expect(mockLogger.info).toHaveBeenCalledWith("test info");
-      });
+    test("reorders (string, Error) error calls to pino format ({ error }, string)", () => {
+      const err = new Error("something failed");
+      wrappedLogger.error("refresh failed", err);
+      expect(mockLogger.error).toHaveBeenCalledWith({ error: err }, "refresh failed");
+    });
 
-      test("passes warn calls through to the underlying logger", () => {
-        wrappedLogger.warn("test warning");
-        expect(mockLogger.warn).toHaveBeenCalledWith("test warning");
-      });
-
-      test("reorders (string, Error) error calls to pino format ({ error }, string)", () => {
-        const err = new Error("something failed");
-        wrappedLogger.error("refresh failed", err);
-        expect(mockLogger.error).toHaveBeenCalledWith({ error: err }, "refresh failed");
-      });
-
-      test("passes through error calls that are not (string, Error) unchanged", () => {
-        wrappedLogger.error("plain error message");
-        expect(mockLogger.error).toHaveBeenCalledWith("plain error message", undefined);
-      });
+    test("passes through error calls that are not (string, Error) unchanged", () => {
+      wrappedLogger.error("plain error message");
+      expect(mockLogger.error).toHaveBeenCalledWith("plain error message", undefined);
     });
   });
 });

--- a/test/unit/config/auth.test.js
+++ b/test/unit/config/auth.test.js
@@ -14,4 +14,8 @@ describe("cache Config Test", () => {
   test("Should pass validation for all fields populated", async () => {
     expect(authConfig).toBeDefined();
   });
+
+  test("Should not expose a client secret", async () => {
+    expect(authConfig).not.toHaveProperty("clientSecret");
+  });
 });


### PR DESCRIPTION
## Summary

The backoffice has been authenticating with federated credentials in every environment since
the feature flag was switched on, so the legacy client secret path is dead code. This removes
the branch, the flag, and the client secret from configuration, leaving federated credentials
as the only way the service authenticates with Entra ID.

## What Changed

- `init()` in the azure auth module now builds the MSAL confidential client with a federated
  client assertion unconditionally, with no branch on a feature flag
- `FEDERATED_CREDENTIALS_ENABLED` removed from the config schema and the config object, so
  setting it in any environment now has no effect
- `AADAR_CLIENT_SECRET` removed from auth config, including the Joi `required()` rule that made
  it a startup prerequisite
- Both Docker Compose files no longer supply the client secret, and a stale `AADAR_TENANT_ID`
  that nothing read has gone with it
- Auth unit tests restructured so federated credentials are the only path under test, plus new
  assertions that neither the MSAL client nor the auth config carries a client secret
- README records that real Entra ID authentication only works on CDP, since the client assertion
  comes from the ECS task role via AWS STS

`AADAR_ENABLED` is untouched. It is the dev auth switch rather than a credential flag, and the
perf test environment depends on it staying `false`.

## Why

The feature flag existed to de-risk the rollout of federated credentials and has served its
purpose. Leaving it in place keeps a long lived Entra ID client secret alive purely to satisfy a
config rule for a code path nothing executes, which means the secret has to be stored in every
CDP environment, supplied as a dummy value by the UI test harness, and rotated on expiry.

## Deployment note

This must be deployed and verified before the credentials are removed from CDP. The currently
deployed image still requires `AADAR_CLIENT_SECRET` at startup, so deleting it first would take
the service down and block rollback. Safe order is deploy, confirm a successful login, then
remove the secrets.