### PR TITLE
feat: (ahwr-2068) withdrawal ui changes

### DIFF
--- a/app/constants/withdrawal.js
+++ b/app/constants/withdrawal.js
@@ -1,0 +1,39 @@
+// The single source of truth for the withdrawal reason and issue-discovery options.
+// Used both to build the radios on withdrawal-claim.njk and to label them on the
+// claim history tab (application-history.js), so the two never drift apart.
+
+export const WITHDRAWAL_REASONS = [
+  {
+    value: "vetSummaryEnteredIncorrectly",
+    text: "Data from the vet summary was entered incorrectly",
+    hint: { text: "For example, date of sample instead of date of visit" },
+  },
+  {
+    value: "differentClaimEntered",
+    text: "Data from a different claim was entered",
+    hint: { text: "For example, information from a follow-up instead of a review" },
+  },
+  {
+    value: "unintentionalTypingError",
+    text: "Data contained an unintentional typing error",
+    hint: { text: "For example, a spelling mistake or incorrect number" },
+  },
+  {
+    value: "incorrectSelectionInService",
+    text: "Incorrect selection was made in the digital service",
+    hint: { text: "For example, yes instead of no" },
+  },
+  {
+    value: "confusingInformationFromVet",
+    text: "Incorrect or confusing information was given by vet",
+    hint: { text: "For example, the wrong box completed in the summary template" },
+  },
+];
+
+export const WITHDRAWAL_ISSUE_DISCOVERIES = [
+  { value: "customerContactedRPA", text: "Customer contacted the RPA" },
+  { value: "evidenceDidNotMatch", text: "Evidence did not match customer's data" },
+];
+
+export const labelsByValue = (items) =>
+  Object.fromEntries(items.map(({ value, text }) => [value, text]));

--- a/app/routes/agreement.js
+++ b/app/routes/agreement.js
@@ -127,7 +127,6 @@ export const buildAgreement = async (
     ? {}
     : getClaimViewStates({
         request,
-        status: application.status,
         currentStatusEvent: null,
         formFlags,
       });

--- a/app/routes/agreement.js
+++ b/app/routes/agreement.js
@@ -125,7 +125,12 @@ export const buildAgreement = async (
 
   const { updateEligiblePiiRedactionAction, updateEligiblePiiRedactionForm } = isRedacted
     ? {}
-    : getClaimViewStates(request, application.status, null, formFlags);
+    : getClaimViewStates({
+        request,
+        status: application.status,
+        currentStatusEvent: null,
+        formFlags,
+      });
 
   const applicationSummaryDetails = buildAgreementSummaryDetails(application, {
     applicationReference,

--- a/app/routes/agreement.js
+++ b/app/routes/agreement.js
@@ -11,7 +11,7 @@ import { getClaims } from "../api/claims.js";
 import { getClaimTableHeader, getClaimTableRows } from "./models/claim-list.js";
 import { FLAG_EMOJI } from "./utils/ui-constants.js";
 import { getHerdBreakdown, getSiteBreakdown } from "../lib/get-claim-breakdown.js";
-import { getClaimViewStates } from "./utils/get-claim-view-states.js";
+import { getApplicationStates } from "./utils/get-application-states.js";
 import { getErrorMessagesByKey } from "./utils/get-error-messages-by-key.js";
 import { getStyleClassByStatus } from "../constants/status.js";
 import { getScheme, POULTRY_SCHEME } from "ffc-ahwr-common-library";
@@ -125,11 +125,7 @@ export const buildAgreement = async (
 
   const { updateEligiblePiiRedactionAction, updateEligiblePiiRedactionForm } = isRedacted
     ? {}
-    : getClaimViewStates({
-        request,
-        currentStatusEvent: null,
-        formFlags,
-      });
+    : getApplicationStates({ request, formFlags });
 
   const applicationSummaryDetails = buildAgreementSummaryDetails(application, {
     applicationReference,

--- a/app/routes/models/application-history.js
+++ b/app/routes/models/application-history.js
@@ -1,5 +1,11 @@
+import nunjucks from "nunjucks";
 import { STATUS } from "ffc-ahwr-common-library";
 import { formattedDateToUk } from "../../lib/display-helper.js";
+import {
+  WITHDRAWAL_REASONS,
+  WITHDRAWAL_ISSUE_DISCOVERIES,
+  labelsByValue,
+} from "../../constants/withdrawal.js";
 const {
   AGREED,
   WITHDRAWN,
@@ -49,6 +55,25 @@ const getAction = (updatedProperty, newValue, oldValue) => {
   return dataProperties[updatedProperty];
 };
 
+const reasonForWithdrawalLabels = labelsByValue(WITHDRAWAL_REASONS);
+const issueDiscoveryLabels = labelsByValue(WITHDRAWAL_ISSUE_DISCOVERIES);
+
+const buildWithdrawalActionHtml = (
+  action,
+  { reasonForWithdrawal, issueDiscovery, withdrawalDetails },
+) =>
+  [
+    action,
+    `<strong>Reason for withdrawal:</strong> ${reasonForWithdrawalLabels[reasonForWithdrawal] ?? ""}`,
+    `<strong>How the issue was discovered:</strong> ${issueDiscoveryLabels[issueDiscovery] ?? ""}`,
+    `<strong>Enter details for why this claim should be withdrawn:</strong> ${nunjucks.lib.escape(withdrawalDetails ?? "")}`,
+  ].join("<br>");
+
+const getActionCell = ({ updatedProperty, newValue, oldValue, withdrawal }) => {
+  const action = getAction(updatedProperty, newValue, oldValue);
+  return withdrawal ? { html: buildWithdrawalActionHtml(action, withdrawal) } : { text: action };
+};
+
 const getHistoryTableHeader = () => [
   { text: "Date" },
   { text: "Time" },
@@ -58,9 +83,8 @@ const getHistoryTableHeader = () => [
 ];
 
 const getHistoryTableRows = (historyRecords) =>
-  historyRecords.map(({ updatedProperty, newValue, oldValue, updatedAt, updatedBy, note }) => {
-    const action = getAction(updatedProperty, newValue, oldValue);
-
+  historyRecords.map((record) => {
+    const { updatedAt, updatedBy, note } = record;
     const updatedDate = new Date(updatedAt);
     return [
       {
@@ -77,7 +101,7 @@ const getHistoryTableRows = (historyRecords) =>
           second: "numeric",
         }),
       },
-      { text: action },
+      getActionCell(record),
       { text: updatedBy },
       { text: note },
     ];

--- a/app/routes/utils/get-application-states.js
+++ b/app/routes/utils/get-application-states.js
@@ -1,0 +1,21 @@
+import { mapAuth } from "../../auth/map-auth.js";
+
+/**
+ * Determines the application-level  view states a caseworker sees
+ * on an agreement view.
+ *
+ * @param {object} params
+ * @param {object} params.request - the Hapi request; supplies the authenticated account and
+ *   the default form flags (`request.query`).
+ * @param {object} [params.formFlags=request.query] - booleans for which inline form is open.
+ * @returns {{ updateEligiblePiiRedactionAction: boolean, updateEligiblePiiRedactionForm: boolean }}
+ */
+export const getApplicationStates = ({ request, formFlags = request.query }) => {
+  const { updateEligiblePiiRedaction } = formFlags;
+  const { isSuperAdmin } = mapAuth(request);
+
+  return {
+    updateEligiblePiiRedactionAction: isSuperAdmin,
+    updateEligiblePiiRedactionForm: isSuperAdmin && updateEligiblePiiRedaction === true,
+  };
+};

--- a/app/routes/utils/get-application-states.test.js
+++ b/app/routes/utils/get-application-states.test.js
@@ -1,0 +1,63 @@
+import { getApplicationStates } from "./get-application-states.js";
+import { permissions } from "../../auth/permissions.js";
+const { administrator } = permissions;
+
+jest.mock("../../config", () => ({
+  config: {
+    superAdmins: ["currentuser@test"],
+  },
+}));
+
+const currentUser = "testUser";
+
+const buildRequest = ({ query = {}, username = "" }) => ({
+  query,
+  auth: {
+    isAuthenticated: true,
+    credentials: {
+      account: { name: currentUser, username },
+      scope: [administrator],
+    },
+  },
+});
+
+describe("getApplicationStates", () => {
+  test("super admin, form flag unset: action available, form closed", () => {
+    const request = buildRequest({ username: "currentUser@test" });
+
+    const state = getApplicationStates({ request });
+
+    expect(state).toEqual({
+      updateEligiblePiiRedactionAction: true,
+      updateEligiblePiiRedactionForm: false,
+    });
+  });
+
+  test("super admin, query: updateEligiblePiiRedaction: action and form", () => {
+    const request = buildRequest({
+      query: { updateEligiblePiiRedaction: true },
+      username: "currentUser@test",
+    });
+
+    const state = getApplicationStates({ request });
+
+    expect(state).toEqual({
+      updateEligiblePiiRedactionAction: true,
+      updateEligiblePiiRedactionForm: true,
+    });
+  });
+
+  test("not a super admin: neither action nor form", () => {
+    const request = buildRequest({
+      query: { updateEligiblePiiRedaction: true },
+      username: "notSuperAdmin@test",
+    });
+
+    const state = getApplicationStates({ request });
+
+    expect(state).toEqual({
+      updateEligiblePiiRedactionAction: false,
+      updateEligiblePiiRedactionForm: false,
+    });
+  });
+});

--- a/app/routes/utils/get-claim-view-states.js
+++ b/app/routes/utils/get-claim-view-states.js
@@ -137,6 +137,9 @@ const getAdminActionsAvailable = ({
   };
 };
 
+/**
+ * This represents the default flags for actions allowed
+ */
 export const DEFAULT_FORM_FLAGS = {
   moveToInCheck: false,
   recommendToPay: false,
@@ -150,6 +153,25 @@ export const DEFAULT_FORM_FLAGS = {
   updateEligiblePiiRedaction: false,
 };
 
+/**
+ * Determines which action buttons and inline forms a caseworker sees on a claim or
+ * agreement view, from their role, the claim status, and which form they have opened.
+ *
+ * Application/agreement views omit `claimStatus`: no claim-status-driven action applies
+ * there, and the super-admin data-edit actions key off role alone.
+ *
+ * @param {object} params
+ * @param {object} params.request - the Hapi request; supplies the authenticated account
+ *   (`request.auth.credentials.account`) and the default form flags (`request.query`).
+ * @param {string} [params.claimStatus] - the claim's current status (a `STATUS` value).
+ * @param {{ updatedBy: string } | null} [params.currentStatusEvent] - the most recent
+ *   status-change event; stops a user authorising or rejecting a claim they last updated.
+ * @param {object} [params.formFlags=request.query] - booleans for which inline form is
+ *   open; see {@link DEFAULT_FORM_FLAGS}.
+ * @param {boolean} [params.isFlagged=false] - whether the application is flagged; blocks withdrawal.
+ * @returns {Object<string, boolean>} the view-state flags (e.g. `moveToInCheckAction`,
+ *   `authoriseForm`, `withdrawAction`, `updateVetsNameForm`) consumed by the templates.
+ */
 export const getClaimViewStates = ({
   request,
   claimStatus,

--- a/app/routes/utils/get-claim-view-states.js
+++ b/app/routes/utils/get-claim-view-states.js
@@ -150,13 +150,13 @@ export const DEFAULT_FORM_FLAGS = {
   updateEligiblePiiRedaction: false,
 };
 
-export const getClaimViewStates = (
+export const getClaimViewStates = ({
   request,
   status,
   currentStatusEvent,
   formFlags = request.query,
   isFlagged = false,
-) => {
+}) => {
   const {
     moveToInCheck,
     recommendToPay,
@@ -216,19 +216,22 @@ const superAdminActionsAvailable = (isSuperAdmin, status, isFlagged, updateFlags
 
   const claimIsntPaidOrReadyToPay = ![STATUS.READY_TO_PAY, STATUS.PAID].includes(status);
 
+  const canChangeClaimData = ![STATUS.WITHDRAWN].includes(status) && isSuperAdmin;
+
   const withdrawAction = canWithdrawClaim({ isSuperAdmin, status, isFlagged });
 
-  const updateStatusAction = isSuperAdmin && claimIsntPaidOrReadyToPay;
-  const updateStatusForm = isSuperAdmin && updateStatus === true && claimIsntPaidOrReadyToPay;
+  const updateStatusAction = canChangeClaimData && claimIsntPaidOrReadyToPay;
+  const updateStatusForm =
+    isSuperAdmin && updateStatus === true && claimIsntPaidOrReadyToPay && canChangeClaimData;
 
-  const updateVetsNameAction = isSuperAdmin;
-  const updateVetsNameForm = isSuperAdmin && updateVetsName === true;
+  const updateVetsNameAction = canChangeClaimData;
+  const updateVetsNameForm = canChangeClaimData && updateVetsName === true;
 
-  const updateVetRCVSNumberAction = isSuperAdmin;
-  const updateVetRCVSNumberForm = isSuperAdmin && updateVetRCVSNumber === true;
+  const updateVetRCVSNumberAction = canChangeClaimData;
+  const updateVetRCVSNumberForm = canChangeClaimData && updateVetRCVSNumber === true;
 
-  const updateDateOfVisitAction = isSuperAdmin;
-  const updateDateOfVisitForm = isSuperAdmin && updateDateOfVisit === true;
+  const updateDateOfVisitAction = canChangeClaimData;
+  const updateDateOfVisitForm = canChangeClaimData && updateDateOfVisit === true;
 
   const updateEligiblePiiRedactionAction = isSuperAdmin;
   const updateEligiblePiiRedactionForm = isSuperAdmin && updateEligiblePiiRedaction === true;

--- a/app/routes/utils/get-claim-view-states.js
+++ b/app/routes/utils/get-claim-view-states.js
@@ -243,8 +243,7 @@ const superAdminActionsAvailable = (isSuperAdmin, claimStatus, isFlagged, update
   const withdrawAction = canWithdrawClaim({ isSuperAdmin, status: claimStatus, isFlagged });
 
   const updateStatusAction = canChangeClaimData && claimIsntPaidOrReadyToPay;
-  const updateStatusForm =
-    isSuperAdmin && updateStatus === true && claimIsntPaidOrReadyToPay && canChangeClaimData;
+  const updateStatusForm = canChangeClaimData && updateStatus === true && claimIsntPaidOrReadyToPay;
 
   const updateVetsNameAction = canChangeClaimData;
   const updateVetsNameForm = canChangeClaimData && updateVetsName === true;

--- a/app/routes/utils/get-claim-view-states.js
+++ b/app/routes/utils/get-claim-view-states.js
@@ -189,7 +189,6 @@ export const getClaimViewStates = ({
     updateVetsName,
     updateDateOfVisit,
     updateVetRCVSNumber,
-    updateEligiblePiiRedaction,
   } = formFlags;
   const { name } = request.auth.credentials.account;
 
@@ -214,7 +213,6 @@ export const getClaimViewStates = ({
     updateVetsName,
     updateVetRCVSNumber,
     updateDateOfVisit,
-    updateEligiblePiiRedaction,
   });
 
   return {
@@ -228,13 +226,7 @@ const statusWasSetByAnotherUser = (currentStatusEvent, name) => {
 };
 
 const superAdminActionsAvailable = (isSuperAdmin, claimStatus, isFlagged, updateFlags) => {
-  const {
-    updateStatus,
-    updateVetsName,
-    updateVetRCVSNumber,
-    updateDateOfVisit,
-    updateEligiblePiiRedaction,
-  } = updateFlags;
+  const { updateStatus, updateVetsName, updateVetRCVSNumber, updateDateOfVisit } = updateFlags;
 
   const claimIsntPaidOrReadyToPay = ![STATUS.READY_TO_PAY, STATUS.PAID].includes(claimStatus);
 
@@ -254,9 +246,6 @@ const superAdminActionsAvailable = (isSuperAdmin, claimStatus, isFlagged, update
   const updateDateOfVisitAction = canChangeClaimData;
   const updateDateOfVisitForm = canChangeClaimData && updateDateOfVisit === true;
 
-  const updateEligiblePiiRedactionAction = isSuperAdmin;
-  const updateEligiblePiiRedactionForm = isSuperAdmin && updateEligiblePiiRedaction === true;
-
   return {
     withdrawAction,
     updateStatusAction,
@@ -267,7 +256,5 @@ const superAdminActionsAvailable = (isSuperAdmin, claimStatus, isFlagged, update
     updateVetRCVSNumberForm,
     updateDateOfVisitAction,
     updateDateOfVisitForm,
-    updateEligiblePiiRedactionAction,
-    updateEligiblePiiRedactionForm,
   };
 };

--- a/app/routes/utils/get-claim-view-states.js
+++ b/app/routes/utils/get-claim-view-states.js
@@ -80,7 +80,7 @@ const getAdminAndAuthoriserAndRecommenderActions = ({
 const getAdminActionsAvailable = ({
   isAdministrator,
   isAuthoriser,
-  status,
+  claimStatus,
   isRecommender,
   moveToInCheck,
   recommendToPay,
@@ -93,10 +93,10 @@ const getAdminActionsAvailable = ({
   const isAdminOrAuthorisor = isAdministrator || isAuthoriser;
   const isAdminOrRecommender = isAdministrator || isRecommender;
   const isAdminOrAuthorisorOrRecommender = isAdministrator || isAuthoriser || isRecommender;
-  const claimIsInCheck = status === STATUS.IN_CHECK;
-  const claimIsOnHold = status === STATUS.ON_HOLD;
-  const claimIsRecommendedToPay = status === STATUS.RECOMMENDED_TO_PAY;
-  const claimIsRecommendedToReject = status === STATUS.RECOMMENDED_TO_REJECT;
+  const claimIsInCheck = claimStatus === STATUS.IN_CHECK;
+  const claimIsOnHold = claimStatus === STATUS.ON_HOLD;
+  const claimIsRecommendedToPay = claimStatus === STATUS.RECOMMENDED_TO_PAY;
+  const claimIsRecommendedToReject = claimStatus === STATUS.RECOMMENDED_TO_REJECT;
 
   const { authoriseAction, authoriseForm, rejectAction, rejectForm } = getAdminAndAuthoriserActions(
     {
@@ -152,7 +152,7 @@ export const DEFAULT_FORM_FLAGS = {
 
 export const getClaimViewStates = ({
   request,
-  status,
+  claimStatus,
   currentStatusEvent,
   formFlags = request.query,
   isFlagged = false,
@@ -176,7 +176,7 @@ export const getClaimViewStates = ({
   const adminActions = getAdminActionsAvailable({
     isAdministrator,
     isAuthoriser,
-    status,
+    claimStatus,
     isRecommender,
     moveToInCheck,
     recommendToPay,
@@ -187,7 +187,7 @@ export const getClaimViewStates = ({
     name,
   });
 
-  const superAdminActions = superAdminActionsAvailable(isSuperAdmin, status, isFlagged, {
+  const superAdminActions = superAdminActionsAvailable(isSuperAdmin, claimStatus, isFlagged, {
     updateStatus,
     updateVetsName,
     updateVetRCVSNumber,
@@ -205,7 +205,7 @@ const statusWasSetByAnotherUser = (currentStatusEvent, name) => {
   return currentStatusEvent && name !== currentStatusEvent.updatedBy;
 };
 
-const superAdminActionsAvailable = (isSuperAdmin, status, isFlagged, updateFlags) => {
+const superAdminActionsAvailable = (isSuperAdmin, claimStatus, isFlagged, updateFlags) => {
   const {
     updateStatus,
     updateVetsName,
@@ -214,11 +214,11 @@ const superAdminActionsAvailable = (isSuperAdmin, status, isFlagged, updateFlags
     updateEligiblePiiRedaction,
   } = updateFlags;
 
-  const claimIsntPaidOrReadyToPay = ![STATUS.READY_TO_PAY, STATUS.PAID].includes(status);
+  const claimIsntPaidOrReadyToPay = ![STATUS.READY_TO_PAY, STATUS.PAID].includes(claimStatus);
 
-  const canChangeClaimData = ![STATUS.WITHDRAWN].includes(status) && isSuperAdmin;
+  const canChangeClaimData = ![STATUS.WITHDRAWN].includes(claimStatus) && isSuperAdmin;
 
-  const withdrawAction = canWithdrawClaim({ isSuperAdmin, status, isFlagged });
+  const withdrawAction = canWithdrawClaim({ isSuperAdmin, status: claimStatus, isFlagged });
 
   const updateStatusAction = canChangeClaimData && claimIsntPaidOrReadyToPay;
   const updateStatusForm =

--- a/app/routes/utils/get-claim-view-states.test.js
+++ b/app/routes/utils/get-claim-view-states.test.js
@@ -490,6 +490,20 @@ describe("getClaimViewStates", () => {
   });
 
   describe("user: super admin", () => {
+    test("claimStatus: withdrawn, cannot change claim data", () => {
+      const request = buildRequest({
+        scope: administrator,
+        username: "currentUser@test",
+      });
+
+      const state = getClaimViewStates({ request, claimStatus: status.WITHDRAWN });
+
+      expect(state).toEqual({
+        ...noPermissions,
+        updateEligiblePiiRedactionAction: true,
+      });
+    });
+
     test("no claim status", () => {
       const request = buildRequest({
         scope: administrator,

--- a/app/routes/utils/get-claim-view-states.test.js
+++ b/app/routes/utils/get-claim-view-states.test.js
@@ -39,8 +39,6 @@ const noPermissions = {
   updateStatusForm: false,
   updateDateOfVisitAction: false,
   updateDateOfVisitForm: false,
-  updateEligiblePiiRedactionAction: false,
-  updateEligiblePiiRedactionForm: false,
   updateVetRCVSNumberAction: false,
   updateVetRCVSNumberForm: false,
   updateVetsNameAction: false,
@@ -498,10 +496,7 @@ describe("getClaimViewStates", () => {
 
       const state = getClaimViewStates({ request, claimStatus: status.WITHDRAWN });
 
-      expect(state).toEqual({
-        ...noPermissions,
-        updateEligiblePiiRedactionAction: true,
-      });
+      expect(state).toEqual(noPermissions);
     });
 
     test("no claim status", () => {
@@ -516,7 +511,6 @@ describe("getClaimViewStates", () => {
         ...noPermissions,
         ...changeDataActions,
         updateStatusAction: true,
-        updateEligiblePiiRedactionAction: true,
       });
     });
 
@@ -533,7 +527,6 @@ describe("getClaimViewStates", () => {
         ...noPermissions,
         ...changeDataActions,
         updateStatusAction: true,
-        updateEligiblePiiRedactionAction: true,
       });
     });
 
@@ -551,7 +544,6 @@ describe("getClaimViewStates", () => {
         ...changeDataActions,
         updateStatusAction: true,
         updateStatusForm: true,
-        updateEligiblePiiRedactionAction: true,
       });
     });
 
@@ -567,7 +559,6 @@ describe("getClaimViewStates", () => {
       expect(state).toEqual({
         ...noPermissions,
         ...changeDataActions,
-        updateEligiblePiiRedactionAction: true,
       });
     });
   });

--- a/app/routes/utils/get-claim-view-states.test.js
+++ b/app/routes/utils/get-claim-view-states.test.js
@@ -27,7 +27,7 @@ describe("getClaimViewStates", () => {
         },
       },
     };
-    const state = getClaimViewStates({ request, status: status.AGREED });
+    const state = getClaimViewStates({ request });
 
     expect(state).toEqual({
       withdrawAction: false,
@@ -66,7 +66,7 @@ describe("getClaimViewStates", () => {
         },
       },
     };
-    const state = getClaimViewStates({ request, status: status.AGREED });
+    const state = getClaimViewStates({ request });
 
     expect(state).toEqual({
       withdrawAction: false,
@@ -105,7 +105,7 @@ describe("getClaimViewStates", () => {
         },
       },
     };
-    const state = getClaimViewStates({ request, status: status.AGREED });
+    const state = getClaimViewStates({ request });
 
     expect(state).toEqual({
       withdrawAction: false,
@@ -144,7 +144,7 @@ describe("getClaimViewStates", () => {
         },
       },
     };
-    const state = getClaimViewStates({ request, status: status.ON_HOLD });
+    const state = getClaimViewStates({ request, claimStatus: status.ON_HOLD });
 
     expect(state).toEqual({
       withdrawAction: false,
@@ -183,7 +183,7 @@ describe("getClaimViewStates", () => {
         },
       },
     };
-    const state = getClaimViewStates({ request, status: status.ON_HOLD });
+    const state = getClaimViewStates({ request, claimStatus: status.ON_HOLD });
 
     expect(state).toEqual({
       withdrawAction: false,
@@ -222,7 +222,7 @@ describe("getClaimViewStates", () => {
         },
       },
     };
-    const state = getClaimViewStates({ request, status: status.ON_HOLD });
+    const state = getClaimViewStates({ request, claimStatus: status.ON_HOLD });
 
     expect(state).toEqual({
       withdrawAction: false,
@@ -261,7 +261,7 @@ describe("getClaimViewStates", () => {
         },
       },
     };
-    const state = getClaimViewStates({ request, status: status.ON_HOLD });
+    const state = getClaimViewStates({ request, claimStatus: status.ON_HOLD });
 
     expect(state).toEqual({
       withdrawAction: false,
@@ -300,7 +300,7 @@ describe("getClaimViewStates", () => {
         },
       },
     };
-    const state = getClaimViewStates({ request, status: status.ON_HOLD });
+    const state = getClaimViewStates({ request, claimStatus: status.ON_HOLD });
 
     expect(state).toEqual({
       withdrawAction: false,
@@ -339,7 +339,7 @@ describe("getClaimViewStates", () => {
         },
       },
     };
-    const state = getClaimViewStates({ request, status: status.ON_HOLD });
+    const state = getClaimViewStates({ request, claimStatus: status.ON_HOLD });
 
     expect(state).toEqual({
       withdrawAction: false,
@@ -378,7 +378,7 @@ describe("getClaimViewStates", () => {
         },
       },
     };
-    const state = getClaimViewStates({ request, status: status.ON_HOLD });
+    const state = getClaimViewStates({ request, claimStatus: status.ON_HOLD });
 
     expect(state).toEqual({
       withdrawAction: false,
@@ -418,7 +418,7 @@ describe("getClaimViewStates", () => {
         },
       },
     };
-    const state = getClaimViewStates({ request, status: status.IN_CHECK });
+    const state = getClaimViewStates({ request, claimStatus: status.IN_CHECK });
 
     expect(state).toEqual({
       withdrawAction: false,
@@ -458,7 +458,7 @@ describe("getClaimViewStates", () => {
         },
       },
     };
-    const state = getClaimViewStates({ request, status: status.IN_CHECK });
+    const state = getClaimViewStates({ request, claimStatus: status.IN_CHECK });
 
     expect(state).toEqual({
       withdrawAction: false,
@@ -498,7 +498,7 @@ describe("getClaimViewStates", () => {
         },
       },
     };
-    const state = getClaimViewStates({ request, status: status.IN_CHECK });
+    const state = getClaimViewStates({ request, claimStatus: status.IN_CHECK });
 
     expect(state).toEqual({
       withdrawAction: false,
@@ -537,7 +537,7 @@ describe("getClaimViewStates", () => {
         },
       },
     };
-    const state = getClaimViewStates({ request, status: status.IN_CHECK });
+    const state = getClaimViewStates({ request, claimStatus: status.IN_CHECK });
 
     expect(state).toEqual({
       withdrawAction: false,
@@ -576,7 +576,7 @@ describe("getClaimViewStates", () => {
         },
       },
     };
-    const state = getClaimViewStates({ request, status: status.IN_CHECK });
+    const state = getClaimViewStates({ request, claimStatus: status.IN_CHECK });
 
     expect(state).toEqual({
       withdrawAction: false,
@@ -615,7 +615,7 @@ describe("getClaimViewStates", () => {
         },
       },
     };
-    const state = getClaimViewStates({ request, status: status.IN_CHECK });
+    const state = getClaimViewStates({ request, claimStatus: status.IN_CHECK });
 
     expect(state).toEqual({
       withdrawAction: false,
@@ -654,7 +654,7 @@ describe("getClaimViewStates", () => {
         },
       },
     };
-    const state = getClaimViewStates({ request, status: status.IN_CHECK });
+    const state = getClaimViewStates({ request, claimStatus: status.IN_CHECK });
 
     expect(state).toEqual({
       withdrawAction: false,
@@ -693,7 +693,7 @@ describe("getClaimViewStates", () => {
         },
       },
     };
-    const state = getClaimViewStates({ request, status: status.IN_CHECK });
+    const state = getClaimViewStates({ request, claimStatus: status.IN_CHECK });
 
     expect(state).toEqual({
       withdrawAction: false,
@@ -732,7 +732,7 @@ describe("getClaimViewStates", () => {
         },
       },
     };
-    const state = getClaimViewStates({ request, status: status.IN_CHECK });
+    const state = getClaimViewStates({ request, claimStatus: status.IN_CHECK });
 
     expect(state).toEqual({
       withdrawAction: false,
@@ -776,7 +776,7 @@ describe("getClaimViewStates", () => {
     };
     const state = getClaimViewStates({
       request,
-      status: status.RECOMMENDED_TO_PAY,
+      claimStatus: status.RECOMMENDED_TO_PAY,
       currentStatusEvent,
     });
 
@@ -822,7 +822,7 @@ describe("getClaimViewStates", () => {
     };
     const state = getClaimViewStates({
       request,
-      status: status.RECOMMENDED_TO_PAY,
+      claimStatus: status.RECOMMENDED_TO_PAY,
       currentStatusEvent,
     });
 
@@ -868,7 +868,7 @@ describe("getClaimViewStates", () => {
     };
     const state = getClaimViewStates({
       request,
-      status: status.RECOMMENDED_TO_PAY,
+      claimStatus: status.RECOMMENDED_TO_PAY,
       currentStatusEvent,
     });
 
@@ -914,7 +914,7 @@ describe("getClaimViewStates", () => {
     };
     const state = getClaimViewStates({
       request,
-      status: status.RECOMMENDED_TO_PAY,
+      claimStatus: status.RECOMMENDED_TO_PAY,
       currentStatusEvent,
     });
 
@@ -960,7 +960,7 @@ describe("getClaimViewStates", () => {
     };
     const state = getClaimViewStates({
       request,
-      status: status.RECOMMENDED_TO_PAY,
+      claimStatus: status.RECOMMENDED_TO_PAY,
       currentStatusEvent,
     });
 
@@ -1006,7 +1006,7 @@ describe("getClaimViewStates", () => {
     };
     const state = getClaimViewStates({
       request,
-      status: status.RECOMMENDED_TO_PAY,
+      claimStatus: status.RECOMMENDED_TO_PAY,
       currentStatusEvent,
     });
 
@@ -1052,7 +1052,7 @@ describe("getClaimViewStates", () => {
     };
     const state = getClaimViewStates({
       request,
-      status: status.RECOMMENDED_TO_PAY,
+      claimStatus: status.RECOMMENDED_TO_PAY,
       currentStatusEvent,
     });
 
@@ -1098,7 +1098,7 @@ describe("getClaimViewStates", () => {
     };
     const state = getClaimViewStates({
       request,
-      status: status.RECOMMENDED_TO_REJECT,
+      claimStatus: status.RECOMMENDED_TO_REJECT,
       currentStatusEvent,
     });
 
@@ -1144,7 +1144,7 @@ describe("getClaimViewStates", () => {
     };
     const state = getClaimViewStates({
       request,
-      status: status.RECOMMENDED_TO_REJECT,
+      claimStatus: status.RECOMMENDED_TO_REJECT,
       currentStatusEvent,
     });
 
@@ -1190,7 +1190,7 @@ describe("getClaimViewStates", () => {
     };
     const state = getClaimViewStates({
       request,
-      status: status.RECOMMENDED_TO_REJECT,
+      claimStatus: status.RECOMMENDED_TO_REJECT,
       currentStatusEvent,
     });
 
@@ -1236,7 +1236,7 @@ describe("getClaimViewStates", () => {
     };
     const state = getClaimViewStates({
       request,
-      status: status.RECOMMENDED_TO_REJECT,
+      claimStatus: status.RECOMMENDED_TO_REJECT,
       currentStatusEvent,
     });
 
@@ -1282,7 +1282,7 @@ describe("getClaimViewStates", () => {
     };
     const state = getClaimViewStates({
       request,
-      status: status.RECOMMENDED_TO_REJECT,
+      claimStatus: status.RECOMMENDED_TO_REJECT,
       currentStatusEvent,
     });
 
@@ -1328,7 +1328,7 @@ describe("getClaimViewStates", () => {
     };
     const state = getClaimViewStates({
       request,
-      status: status.RECOMMENDED_TO_REJECT,
+      claimStatus: status.RECOMMENDED_TO_REJECT,
       currentStatusEvent,
     });
 
@@ -1374,7 +1374,7 @@ describe("getClaimViewStates", () => {
     };
     const state = getClaimViewStates({
       request,
-      status: status.RECOMMENDED_TO_REJECT,
+      claimStatus: status.RECOMMENDED_TO_REJECT,
       currentStatusEvent,
     });
 
@@ -1420,7 +1420,7 @@ describe("getClaimViewStates", () => {
     };
     const state = getClaimViewStates({
       request,
-      status: status.RECOMMENDED_TO_REJECT,
+      claimStatus: status.RECOMMENDED_TO_REJECT,
       currentStatusEvent,
     });
 
@@ -1448,7 +1448,7 @@ describe("getClaimViewStates", () => {
     });
   });
 
-  test("statusUpdateAction, status: any, user: admin", () => {
+  test("statusUpdateAction, claimStatus: any, user: admin", () => {
     const request = {
       query: {
         updateStatus: false,
@@ -1462,7 +1462,7 @@ describe("getClaimViewStates", () => {
       },
     };
 
-    const state = getClaimViewStates({ request, status: status.REJECTED });
+    const state = getClaimViewStates({ request, claimStatus: status.REJECTED });
 
     expect(state).toEqual({
       withdrawAction: false,
@@ -1488,7 +1488,7 @@ describe("getClaimViewStates", () => {
     });
   });
 
-  test("statusUpdateAction, status: any, user: admin & super admin", () => {
+  test("statusUpdateAction, claimStatus: any, user: admin & super admin", () => {
     const request = {
       query: {
         updateStatus: false,
@@ -1502,7 +1502,7 @@ describe("getClaimViewStates", () => {
       },
     };
 
-    const state = getClaimViewStates({ request, status: status.REJECTED });
+    const state = getClaimViewStates({ request, claimStatus: status.REJECTED });
 
     expect(state).toEqual({
       withdrawAction: false,
@@ -1528,7 +1528,7 @@ describe("getClaimViewStates", () => {
     });
   });
 
-  test("statusUpdateForm, status: any, query: update, user: admin", () => {
+  test("statusUpdateForm, claimStatus: any, query: update, user: admin", () => {
     const request = {
       query: {
         update: true,
@@ -1542,7 +1542,7 @@ describe("getClaimViewStates", () => {
       },
     };
 
-    const state = getClaimViewStates({ request, status: status.REJECTED });
+    const state = getClaimViewStates({ request, claimStatus: status.REJECTED });
 
     expect(state).toEqual({
       withdrawAction: false,
@@ -1568,7 +1568,7 @@ describe("getClaimViewStates", () => {
     });
   });
 
-  test("statusUpdateForm, status: any, query: updateStatus, user: admin & super admin", () => {
+  test("statusUpdateForm, claimStatus: any, query: updateStatus, user: admin & super admin", () => {
     const request = {
       query: {
         updateStatus: true,
@@ -1582,7 +1582,7 @@ describe("getClaimViewStates", () => {
       },
     };
 
-    const state = getClaimViewStates({ request, status: status.REJECTED });
+    const state = getClaimViewStates({ request, claimStatus: status.REJECTED });
 
     expect(state).toEqual({
       withdrawAction: false,
@@ -1608,7 +1608,7 @@ describe("getClaimViewStates", () => {
     });
   });
 
-  test("statusUpdateForm, status: ready to pay, query: updateStatus, user: admin & super admin", () => {
+  test("statusUpdateForm, claimStatus: ready to pay, query: updateStatus, user: admin & super admin", () => {
     const request = {
       query: {
         updateStatus: true,
@@ -1622,7 +1622,7 @@ describe("getClaimViewStates", () => {
       },
     };
 
-    const state = getClaimViewStates({ request, status: status.READY_TO_PAY });
+    const state = getClaimViewStates({ request, claimStatus: status.READY_TO_PAY });
 
     expect(state).toEqual({
       withdrawAction: false,
@@ -1671,7 +1671,7 @@ describe("withdraw button", () => {
   test("withdrawAction: true when super admin, status in check and toggle enabled", () => {
     const state = getClaimViewStates({
       request: inCheckSuperAdminRequest,
-      status: status.IN_CHECK,
+      claimStatus: status.IN_CHECK,
     });
 
     expect(state.withdrawAction).toBe(true);
@@ -1682,7 +1682,7 @@ describe("withdraw button", () => {
 
     const state = getClaimViewStates({
       request: inCheckSuperAdminRequest,
-      status: status.IN_CHECK,
+      claimStatus: status.IN_CHECK,
     });
 
     expect(state.withdrawAction).toBe(false);
@@ -1691,7 +1691,7 @@ describe("withdraw button", () => {
   test("withdrawAction: false when super admin but status is not in check", () => {
     const state = getClaimViewStates({
       request: inCheckSuperAdminRequest,
-      status: status.READY_TO_PAY,
+      claimStatus: status.READY_TO_PAY,
     });
 
     expect(state.withdrawAction).toBe(false);
@@ -1702,7 +1702,7 @@ describe("withdraw button", () => {
 
     const state = getClaimViewStates({
       request: inCheckSuperAdminRequest,
-      status: status.IN_CHECK,
+      claimStatus: status.IN_CHECK,
       currentStatusEvent: undefined,
       formFlags: inCheckSuperAdminRequest.query,
       isFlagged,
@@ -1726,7 +1726,7 @@ describe("withdraw button", () => {
       },
     };
 
-    const state = getClaimViewStates({ request, status: status.IN_CHECK });
+    const state = getClaimViewStates({ request, claimStatus: status.IN_CHECK });
 
     expect(state.withdrawAction).toBe(false);
   });

--- a/app/routes/utils/get-claim-view-states.test.js
+++ b/app/routes/utils/get-claim-view-states.test.js
@@ -13,1577 +13,1639 @@ jest.mock("../../config", () => ({
 
 const currentUser = "testUser";
 
-test("status: agreed, user: admin", () => {
-  const request = {
-    query: {
-      withdraw: false,
-    },
-    auth: {
-      isAuthenticated: true,
-      credentials: {
-        account: { name: currentUser, username: "" },
-        scope: [administrator],
+describe("getClaimViewStates", () => {
+  test("status: agreed, user: admin", () => {
+    const request = {
+      query: {
+        withdraw: false,
       },
-    },
-  };
-  const state = getClaimViewStates(request, status.AGREED);
+      auth: {
+        isAuthenticated: true,
+        credentials: {
+          account: { name: currentUser, username: "" },
+          scope: [administrator],
+        },
+      },
+    };
+    const state = getClaimViewStates({ request, status: status.AGREED });
 
-  expect(state).toEqual({
-    withdrawAction: false,
-    moveToInCheckAction: false,
-    moveToInCheckForm: false,
-    recommendAction: false,
-    recommendToPayForm: false,
-    recommendToRejectForm: false,
-    authoriseAction: false,
-    authoriseForm: false,
-    rejectAction: false,
-    rejectForm: false,
-    updateStatusAction: false,
-    updateStatusForm: false,
-    updateDateOfVisitAction: false,
-    updateDateOfVisitForm: false,
-    updateEligiblePiiRedactionAction: false,
-    updateEligiblePiiRedactionForm: false,
-    updateVetRCVSNumberAction: false,
-    updateVetRCVSNumberForm: false,
-    updateVetsNameAction: false,
-    updateVetsNameForm: false,
+    expect(state).toEqual({
+      withdrawAction: false,
+      moveToInCheckAction: false,
+      moveToInCheckForm: false,
+      recommendAction: false,
+      recommendToPayForm: false,
+      recommendToRejectForm: false,
+      authoriseAction: false,
+      authoriseForm: false,
+      rejectAction: false,
+      rejectForm: false,
+      updateStatusAction: false,
+      updateStatusForm: false,
+      updateDateOfVisitAction: false,
+      updateDateOfVisitForm: false,
+      updateEligiblePiiRedactionAction: false,
+      updateEligiblePiiRedactionForm: false,
+      updateVetRCVSNumberAction: false,
+      updateVetRCVSNumberForm: false,
+      updateVetsNameAction: false,
+      updateVetsNameForm: false,
+    });
   });
-});
 
-test("status: agreed, user: recommender", () => {
-  const request = {
-    query: {
-      withdraw: false,
-    },
-    auth: {
-      isAuthenticated: true,
-      credentials: {
-        account: { name: currentUser, username: "" },
-        scope: [recommender],
+  test("status: agreed, user: recommender", () => {
+    const request = {
+      query: {
+        withdraw: false,
       },
-    },
-  };
-  const state = getClaimViewStates(request, status.AGREED);
+      auth: {
+        isAuthenticated: true,
+        credentials: {
+          account: { name: currentUser, username: "" },
+          scope: [recommender],
+        },
+      },
+    };
+    const state = getClaimViewStates({ request, status: status.AGREED });
 
-  expect(state).toEqual({
-    withdrawAction: false,
-    moveToInCheckAction: false,
-    moveToInCheckForm: false,
-    recommendAction: false,
-    recommendToPayForm: false,
-    recommendToRejectForm: false,
-    authoriseAction: false,
-    authoriseForm: false,
-    rejectAction: false,
-    rejectForm: false,
-    updateStatusAction: false,
-    updateStatusForm: false,
-    updateDateOfVisitAction: false,
-    updateDateOfVisitForm: false,
-    updateEligiblePiiRedactionAction: false,
-    updateEligiblePiiRedactionForm: false,
-    updateVetRCVSNumberAction: false,
-    updateVetRCVSNumberForm: false,
-    updateVetsNameAction: false,
-    updateVetsNameForm: false,
+    expect(state).toEqual({
+      withdrawAction: false,
+      moveToInCheckAction: false,
+      moveToInCheckForm: false,
+      recommendAction: false,
+      recommendToPayForm: false,
+      recommendToRejectForm: false,
+      authoriseAction: false,
+      authoriseForm: false,
+      rejectAction: false,
+      rejectForm: false,
+      updateStatusAction: false,
+      updateStatusForm: false,
+      updateDateOfVisitAction: false,
+      updateDateOfVisitForm: false,
+      updateEligiblePiiRedactionAction: false,
+      updateEligiblePiiRedactionForm: false,
+      updateVetRCVSNumberAction: false,
+      updateVetRCVSNumberForm: false,
+      updateVetsNameAction: false,
+      updateVetsNameForm: false,
+    });
   });
-});
 
-test("status: agreed, user: authoriser", () => {
-  const request = {
-    query: {
-      withdraw: false,
-    },
-    auth: {
-      isAuthenticated: true,
-      credentials: {
-        account: { name: currentUser, username: "" },
-        scope: [authoriser],
+  test("status: agreed, user: authoriser", () => {
+    const request = {
+      query: {
+        withdraw: false,
       },
-    },
-  };
-  const state = getClaimViewStates(request, status.AGREED);
+      auth: {
+        isAuthenticated: true,
+        credentials: {
+          account: { name: currentUser, username: "" },
+          scope: [authoriser],
+        },
+      },
+    };
+    const state = getClaimViewStates({ request, status: status.AGREED });
 
-  expect(state).toEqual({
-    withdrawAction: false,
-    moveToInCheckAction: false,
-    moveToInCheckForm: false,
-    recommendAction: false,
-    recommendToPayForm: false,
-    recommendToRejectForm: false,
-    authoriseAction: false,
-    authoriseForm: false,
-    rejectAction: false,
-    rejectForm: false,
-    updateStatusAction: false,
-    updateStatusForm: false,
-    updateDateOfVisitAction: false,
-    updateDateOfVisitForm: false,
-    updateEligiblePiiRedactionAction: false,
-    updateEligiblePiiRedactionForm: false,
-    updateVetRCVSNumberAction: false,
-    updateVetRCVSNumberForm: false,
-    updateVetsNameAction: false,
-    updateVetsNameForm: false,
+    expect(state).toEqual({
+      withdrawAction: false,
+      moveToInCheckAction: false,
+      moveToInCheckForm: false,
+      recommendAction: false,
+      recommendToPayForm: false,
+      recommendToRejectForm: false,
+      authoriseAction: false,
+      authoriseForm: false,
+      rejectAction: false,
+      rejectForm: false,
+      updateStatusAction: false,
+      updateStatusForm: false,
+      updateDateOfVisitAction: false,
+      updateDateOfVisitForm: false,
+      updateEligiblePiiRedactionAction: false,
+      updateEligiblePiiRedactionForm: false,
+      updateVetRCVSNumberAction: false,
+      updateVetRCVSNumberForm: false,
+      updateVetsNameAction: false,
+      updateVetsNameForm: false,
+    });
   });
-});
 
-test("status: on hold, user: admin", () => {
-  const request = {
-    query: {
-      moveToInCheck: false,
-    },
-    auth: {
-      isAuthenticated: true,
-      credentials: {
-        account: { name: currentUser, username: "" },
-        scope: [administrator],
+  test("status: on hold, user: admin", () => {
+    const request = {
+      query: {
+        moveToInCheck: false,
       },
-    },
-  };
-  const state = getClaimViewStates(request, status.ON_HOLD);
+      auth: {
+        isAuthenticated: true,
+        credentials: {
+          account: { name: currentUser, username: "" },
+          scope: [administrator],
+        },
+      },
+    };
+    const state = getClaimViewStates({ request, status: status.ON_HOLD });
 
-  expect(state).toEqual({
-    withdrawAction: false,
-    moveToInCheckAction: true,
-    moveToInCheckForm: false,
-    recommendAction: false,
-    recommendToPayForm: false,
-    recommendToRejectForm: false,
-    authoriseAction: false,
-    authoriseForm: false,
-    rejectAction: false,
-    rejectForm: false,
-    updateStatusAction: false,
-    updateStatusForm: false,
-    updateDateOfVisitAction: false,
-    updateDateOfVisitForm: false,
-    updateEligiblePiiRedactionAction: false,
-    updateEligiblePiiRedactionForm: false,
-    updateVetRCVSNumberAction: false,
-    updateVetRCVSNumberForm: false,
-    updateVetsNameAction: false,
-    updateVetsNameForm: false,
+    expect(state).toEqual({
+      withdrawAction: false,
+      moveToInCheckAction: true,
+      moveToInCheckForm: false,
+      recommendAction: false,
+      recommendToPayForm: false,
+      recommendToRejectForm: false,
+      authoriseAction: false,
+      authoriseForm: false,
+      rejectAction: false,
+      rejectForm: false,
+      updateStatusAction: false,
+      updateStatusForm: false,
+      updateDateOfVisitAction: false,
+      updateDateOfVisitForm: false,
+      updateEligiblePiiRedactionAction: false,
+      updateEligiblePiiRedactionForm: false,
+      updateVetRCVSNumberAction: false,
+      updateVetRCVSNumberForm: false,
+      updateVetsNameAction: false,
+      updateVetsNameForm: false,
+    });
   });
-});
 
-test("status: on hold, user: recommender", () => {
-  const request = {
-    query: {
-      moveToInCheck: false,
-    },
-    auth: {
-      isAuthenticated: true,
-      credentials: {
-        account: { name: currentUser, username: "" },
-        scope: [recommender],
+  test("status: on hold, user: recommender", () => {
+    const request = {
+      query: {
+        moveToInCheck: false,
       },
-    },
-  };
-  const state = getClaimViewStates(request, status.ON_HOLD);
+      auth: {
+        isAuthenticated: true,
+        credentials: {
+          account: { name: currentUser, username: "" },
+          scope: [recommender],
+        },
+      },
+    };
+    const state = getClaimViewStates({ request, status: status.ON_HOLD });
 
-  expect(state).toEqual({
-    withdrawAction: false,
-    moveToInCheckAction: true,
-    moveToInCheckForm: false,
-    recommendAction: false,
-    recommendToPayForm: false,
-    recommendToRejectForm: false,
-    authoriseAction: false,
-    authoriseForm: false,
-    rejectAction: false,
-    rejectForm: false,
-    updateStatusAction: false,
-    updateStatusForm: false,
-    updateDateOfVisitAction: false,
-    updateDateOfVisitForm: false,
-    updateEligiblePiiRedactionAction: false,
-    updateEligiblePiiRedactionForm: false,
-    updateVetRCVSNumberAction: false,
-    updateVetRCVSNumberForm: false,
-    updateVetsNameAction: false,
-    updateVetsNameForm: false,
+    expect(state).toEqual({
+      withdrawAction: false,
+      moveToInCheckAction: true,
+      moveToInCheckForm: false,
+      recommendAction: false,
+      recommendToPayForm: false,
+      recommendToRejectForm: false,
+      authoriseAction: false,
+      authoriseForm: false,
+      rejectAction: false,
+      rejectForm: false,
+      updateStatusAction: false,
+      updateStatusForm: false,
+      updateDateOfVisitAction: false,
+      updateDateOfVisitForm: false,
+      updateEligiblePiiRedactionAction: false,
+      updateEligiblePiiRedactionForm: false,
+      updateVetRCVSNumberAction: false,
+      updateVetRCVSNumberForm: false,
+      updateVetsNameAction: false,
+      updateVetsNameForm: false,
+    });
   });
-});
 
-test("status: on hold, user: authoriser", () => {
-  const request = {
-    query: {
-      moveToInCheck: false,
-    },
-    auth: {
-      isAuthenticated: true,
-      credentials: {
-        account: { name: currentUser, username: "" },
-        scope: [authoriser],
+  test("status: on hold, user: authoriser", () => {
+    const request = {
+      query: {
+        moveToInCheck: false,
       },
-    },
-  };
-  const state = getClaimViewStates(request, status.ON_HOLD);
+      auth: {
+        isAuthenticated: true,
+        credentials: {
+          account: { name: currentUser, username: "" },
+          scope: [authoriser],
+        },
+      },
+    };
+    const state = getClaimViewStates({ request, status: status.ON_HOLD });
 
-  expect(state).toEqual({
-    withdrawAction: false,
-    moveToInCheckAction: true,
-    moveToInCheckForm: false,
-    recommendAction: false,
-    recommendToPayForm: false,
-    recommendToRejectForm: false,
-    authoriseAction: false,
-    authoriseForm: false,
-    rejectAction: false,
-    rejectForm: false,
-    updateStatusAction: false,
-    updateStatusForm: false,
-    updateDateOfVisitAction: false,
-    updateDateOfVisitForm: false,
-    updateEligiblePiiRedactionAction: false,
-    updateEligiblePiiRedactionForm: false,
-    updateVetRCVSNumberAction: false,
-    updateVetRCVSNumberForm: false,
-    updateVetsNameAction: false,
-    updateVetsNameForm: false,
+    expect(state).toEqual({
+      withdrawAction: false,
+      moveToInCheckAction: true,
+      moveToInCheckForm: false,
+      recommendAction: false,
+      recommendToPayForm: false,
+      recommendToRejectForm: false,
+      authoriseAction: false,
+      authoriseForm: false,
+      rejectAction: false,
+      rejectForm: false,
+      updateStatusAction: false,
+      updateStatusForm: false,
+      updateDateOfVisitAction: false,
+      updateDateOfVisitForm: false,
+      updateEligiblePiiRedactionAction: false,
+      updateEligiblePiiRedactionForm: false,
+      updateVetRCVSNumberAction: false,
+      updateVetRCVSNumberForm: false,
+      updateVetsNameAction: false,
+      updateVetsNameForm: false,
+    });
   });
-});
 
-test("status: on hold, user: user", () => {
-  const request = {
-    query: {
-      moveToInCheck: false,
-    },
-    auth: {
-      isAuthenticated: true,
-      credentials: {
-        account: { name: currentUser, username: "" },
-        scope: [user],
+  test("status: on hold, user: user", () => {
+    const request = {
+      query: {
+        moveToInCheck: false,
       },
-    },
-  };
-  const state = getClaimViewStates(request, status.ON_HOLD);
+      auth: {
+        isAuthenticated: true,
+        credentials: {
+          account: { name: currentUser, username: "" },
+          scope: [user],
+        },
+      },
+    };
+    const state = getClaimViewStates({ request, status: status.ON_HOLD });
 
-  expect(state).toEqual({
-    withdrawAction: false,
-    moveToInCheckAction: false,
-    moveToInCheckForm: false,
-    recommendAction: false,
-    recommendToPayForm: false,
-    recommendToRejectForm: false,
-    authoriseAction: false,
-    authoriseForm: false,
-    rejectAction: false,
-    rejectForm: false,
-    updateStatusAction: false,
-    updateStatusForm: false,
-    updateDateOfVisitAction: false,
-    updateDateOfVisitForm: false,
-    updateEligiblePiiRedactionAction: false,
-    updateEligiblePiiRedactionForm: false,
-    updateVetRCVSNumberAction: false,
-    updateVetRCVSNumberForm: false,
-    updateVetsNameAction: false,
-    updateVetsNameForm: false,
+    expect(state).toEqual({
+      withdrawAction: false,
+      moveToInCheckAction: false,
+      moveToInCheckForm: false,
+      recommendAction: false,
+      recommendToPayForm: false,
+      recommendToRejectForm: false,
+      authoriseAction: false,
+      authoriseForm: false,
+      rejectAction: false,
+      rejectForm: false,
+      updateStatusAction: false,
+      updateStatusForm: false,
+      updateDateOfVisitAction: false,
+      updateDateOfVisitForm: false,
+      updateEligiblePiiRedactionAction: false,
+      updateEligiblePiiRedactionForm: false,
+      updateVetRCVSNumberAction: false,
+      updateVetRCVSNumberForm: false,
+      updateVetsNameAction: false,
+      updateVetsNameForm: false,
+    });
   });
-});
 
-test("status: on hold, query: moveToInCheck, user: admin", () => {
-  const request = {
-    query: {
-      moveToInCheck: true,
-    },
-    auth: {
-      isAuthenticated: true,
-      credentials: {
-        account: { name: currentUser, username: "" },
-        scope: [administrator],
+  test("status: on hold, query: moveToInCheck, user: admin", () => {
+    const request = {
+      query: {
+        moveToInCheck: true,
       },
-    },
-  };
-  const state = getClaimViewStates(request, status.ON_HOLD);
+      auth: {
+        isAuthenticated: true,
+        credentials: {
+          account: { name: currentUser, username: "" },
+          scope: [administrator],
+        },
+      },
+    };
+    const state = getClaimViewStates({ request, status: status.ON_HOLD });
 
-  expect(state).toEqual({
-    withdrawAction: false,
-    moveToInCheckAction: false,
-    moveToInCheckForm: true,
-    recommendAction: false,
-    recommendToPayForm: false,
-    recommendToRejectForm: false,
-    authoriseAction: false,
-    authoriseForm: false,
-    rejectAction: false,
-    rejectForm: false,
-    updateStatusAction: false,
-    updateStatusForm: false,
-    updateDateOfVisitAction: false,
-    updateDateOfVisitForm: false,
-    updateEligiblePiiRedactionAction: false,
-    updateEligiblePiiRedactionForm: false,
-    updateVetRCVSNumberAction: false,
-    updateVetRCVSNumberForm: false,
-    updateVetsNameAction: false,
-    updateVetsNameForm: false,
+    expect(state).toEqual({
+      withdrawAction: false,
+      moveToInCheckAction: false,
+      moveToInCheckForm: true,
+      recommendAction: false,
+      recommendToPayForm: false,
+      recommendToRejectForm: false,
+      authoriseAction: false,
+      authoriseForm: false,
+      rejectAction: false,
+      rejectForm: false,
+      updateStatusAction: false,
+      updateStatusForm: false,
+      updateDateOfVisitAction: false,
+      updateDateOfVisitForm: false,
+      updateEligiblePiiRedactionAction: false,
+      updateEligiblePiiRedactionForm: false,
+      updateVetRCVSNumberAction: false,
+      updateVetRCVSNumberForm: false,
+      updateVetsNameAction: false,
+      updateVetsNameForm: false,
+    });
   });
-});
 
-test("status: on hold, query: moveToInCheck, user: recommender", () => {
-  const request = {
-    query: {
-      moveToInCheck: true,
-    },
-    auth: {
-      isAuthenticated: true,
-      credentials: {
-        account: { name: currentUser, username: "" },
-        scope: [recommender],
+  test("status: on hold, query: moveToInCheck, user: recommender", () => {
+    const request = {
+      query: {
+        moveToInCheck: true,
       },
-    },
-  };
-  const state = getClaimViewStates(request, status.ON_HOLD);
+      auth: {
+        isAuthenticated: true,
+        credentials: {
+          account: { name: currentUser, username: "" },
+          scope: [recommender],
+        },
+      },
+    };
+    const state = getClaimViewStates({ request, status: status.ON_HOLD });
 
-  expect(state).toEqual({
-    withdrawAction: false,
-    moveToInCheckAction: false,
-    moveToInCheckForm: true,
-    recommendAction: false,
-    recommendToPayForm: false,
-    recommendToRejectForm: false,
-    authoriseAction: false,
-    authoriseForm: false,
-    rejectAction: false,
-    rejectForm: false,
-    updateStatusAction: false,
-    updateStatusForm: false,
-    updateDateOfVisitAction: false,
-    updateDateOfVisitForm: false,
-    updateEligiblePiiRedactionAction: false,
-    updateEligiblePiiRedactionForm: false,
-    updateVetRCVSNumberAction: false,
-    updateVetRCVSNumberForm: false,
-    updateVetsNameAction: false,
-    updateVetsNameForm: false,
+    expect(state).toEqual({
+      withdrawAction: false,
+      moveToInCheckAction: false,
+      moveToInCheckForm: true,
+      recommendAction: false,
+      recommendToPayForm: false,
+      recommendToRejectForm: false,
+      authoriseAction: false,
+      authoriseForm: false,
+      rejectAction: false,
+      rejectForm: false,
+      updateStatusAction: false,
+      updateStatusForm: false,
+      updateDateOfVisitAction: false,
+      updateDateOfVisitForm: false,
+      updateEligiblePiiRedactionAction: false,
+      updateEligiblePiiRedactionForm: false,
+      updateVetRCVSNumberAction: false,
+      updateVetRCVSNumberForm: false,
+      updateVetsNameAction: false,
+      updateVetsNameForm: false,
+    });
   });
-});
 
-test("status: on hold, query: moveToInCheck, user: authoriser", () => {
-  const request = {
-    query: {
-      moveToInCheck: true,
-    },
-    auth: {
-      isAuthenticated: true,
-      credentials: {
-        account: { name: currentUser, username: "" },
-        scope: [authoriser],
+  test("status: on hold, query: moveToInCheck, user: authoriser", () => {
+    const request = {
+      query: {
+        moveToInCheck: true,
       },
-    },
-  };
-  const state = getClaimViewStates(request, status.ON_HOLD);
+      auth: {
+        isAuthenticated: true,
+        credentials: {
+          account: { name: currentUser, username: "" },
+          scope: [authoriser],
+        },
+      },
+    };
+    const state = getClaimViewStates({ request, status: status.ON_HOLD });
 
-  expect(state).toEqual({
-    withdrawAction: false,
-    moveToInCheckAction: false,
-    moveToInCheckForm: true,
-    recommendAction: false,
-    recommendToPayForm: false,
-    recommendToRejectForm: false,
-    authoriseAction: false,
-    authoriseForm: false,
-    rejectAction: false,
-    rejectForm: false,
-    updateStatusAction: false,
-    updateStatusForm: false,
-    updateDateOfVisitAction: false,
-    updateDateOfVisitForm: false,
-    updateEligiblePiiRedactionAction: false,
-    updateEligiblePiiRedactionForm: false,
-    updateVetRCVSNumberAction: false,
-    updateVetRCVSNumberForm: false,
-    updateVetsNameAction: false,
-    updateVetsNameForm: false,
+    expect(state).toEqual({
+      withdrawAction: false,
+      moveToInCheckAction: false,
+      moveToInCheckForm: true,
+      recommendAction: false,
+      recommendToPayForm: false,
+      recommendToRejectForm: false,
+      authoriseAction: false,
+      authoriseForm: false,
+      rejectAction: false,
+      rejectForm: false,
+      updateStatusAction: false,
+      updateStatusForm: false,
+      updateDateOfVisitAction: false,
+      updateDateOfVisitForm: false,
+      updateEligiblePiiRedactionAction: false,
+      updateEligiblePiiRedactionForm: false,
+      updateVetRCVSNumberAction: false,
+      updateVetRCVSNumberForm: false,
+      updateVetsNameAction: false,
+      updateVetsNameForm: false,
+    });
   });
-});
 
-test("status: in check, user: admin", () => {
-  const request = {
-    query: {
-      recommendToPay: false,
-      recommendToReject: false,
-    },
-    auth: {
-      isAuthenticated: true,
-      credentials: {
-        account: { name: currentUser, username: "" },
-        scope: [administrator],
+  test("status: in check, user: admin", () => {
+    const request = {
+      query: {
+        recommendToPay: false,
+        recommendToReject: false,
       },
-    },
-  };
-  const state = getClaimViewStates(request, status.IN_CHECK);
+      auth: {
+        isAuthenticated: true,
+        credentials: {
+          account: { name: currentUser, username: "" },
+          scope: [administrator],
+        },
+      },
+    };
+    const state = getClaimViewStates({ request, status: status.IN_CHECK });
 
-  expect(state).toEqual({
-    withdrawAction: false,
-    moveToInCheckAction: false,
-    moveToInCheckForm: false,
-    recommendAction: true,
-    recommendToPayForm: false,
-    recommendToRejectForm: false,
-    authoriseAction: false,
-    authoriseForm: false,
-    rejectAction: false,
-    rejectForm: false,
-    updateStatusAction: false,
-    updateStatusForm: false,
-    updateDateOfVisitAction: false,
-    updateDateOfVisitForm: false,
-    updateEligiblePiiRedactionAction: false,
-    updateEligiblePiiRedactionForm: false,
-    updateVetRCVSNumberAction: false,
-    updateVetRCVSNumberForm: false,
-    updateVetsNameAction: false,
-    updateVetsNameForm: false,
+    expect(state).toEqual({
+      withdrawAction: false,
+      moveToInCheckAction: false,
+      moveToInCheckForm: false,
+      recommendAction: true,
+      recommendToPayForm: false,
+      recommendToRejectForm: false,
+      authoriseAction: false,
+      authoriseForm: false,
+      rejectAction: false,
+      rejectForm: false,
+      updateStatusAction: false,
+      updateStatusForm: false,
+      updateDateOfVisitAction: false,
+      updateDateOfVisitForm: false,
+      updateEligiblePiiRedactionAction: false,
+      updateEligiblePiiRedactionForm: false,
+      updateVetRCVSNumberAction: false,
+      updateVetRCVSNumberForm: false,
+      updateVetsNameAction: false,
+      updateVetsNameForm: false,
+    });
   });
-});
 
-test("status: in check, user: recommender", () => {
-  const request = {
-    query: {
-      recommendToPay: false,
-      recommendToReject: false,
-    },
-    auth: {
-      isAuthenticated: true,
-      credentials: {
-        account: { name: currentUser, username: "" },
-        scope: [recommender],
+  test("status: in check, user: recommender", () => {
+    const request = {
+      query: {
+        recommendToPay: false,
+        recommendToReject: false,
       },
-    },
-  };
-  const state = getClaimViewStates(request, status.IN_CHECK);
+      auth: {
+        isAuthenticated: true,
+        credentials: {
+          account: { name: currentUser, username: "" },
+          scope: [recommender],
+        },
+      },
+    };
+    const state = getClaimViewStates({ request, status: status.IN_CHECK });
 
-  expect(state).toEqual({
-    withdrawAction: false,
-    moveToInCheckAction: false,
-    moveToInCheckForm: false,
-    recommendAction: true,
-    recommendToPayForm: false,
-    recommendToRejectForm: false,
-    authoriseAction: false,
-    authoriseForm: false,
-    rejectAction: false,
-    rejectForm: false,
-    updateStatusAction: false,
-    updateStatusForm: false,
-    updateDateOfVisitAction: false,
-    updateDateOfVisitForm: false,
-    updateEligiblePiiRedactionAction: false,
-    updateEligiblePiiRedactionForm: false,
-    updateVetRCVSNumberAction: false,
-    updateVetRCVSNumberForm: false,
-    updateVetsNameAction: false,
-    updateVetsNameForm: false,
+    expect(state).toEqual({
+      withdrawAction: false,
+      moveToInCheckAction: false,
+      moveToInCheckForm: false,
+      recommendAction: true,
+      recommendToPayForm: false,
+      recommendToRejectForm: false,
+      authoriseAction: false,
+      authoriseForm: false,
+      rejectAction: false,
+      rejectForm: false,
+      updateStatusAction: false,
+      updateStatusForm: false,
+      updateDateOfVisitAction: false,
+      updateDateOfVisitForm: false,
+      updateEligiblePiiRedactionAction: false,
+      updateEligiblePiiRedactionForm: false,
+      updateVetRCVSNumberAction: false,
+      updateVetRCVSNumberForm: false,
+      updateVetsNameAction: false,
+      updateVetsNameForm: false,
+    });
   });
-});
 
-test("status: in check, user: authoriser", () => {
-  const request = {
-    query: {
-      recommendToPay: false,
-      recommendToReject: false,
-    },
-    auth: {
-      isAuthenticated: true,
-      credentials: {
-        account: { name: currentUser, username: "" },
-        scope: [authoriser],
+  test("status: in check, user: authoriser", () => {
+    const request = {
+      query: {
+        recommendToPay: false,
+        recommendToReject: false,
       },
-    },
-  };
-  const state = getClaimViewStates(request, status.IN_CHECK);
+      auth: {
+        isAuthenticated: true,
+        credentials: {
+          account: { name: currentUser, username: "" },
+          scope: [authoriser],
+        },
+      },
+    };
+    const state = getClaimViewStates({ request, status: status.IN_CHECK });
 
-  expect(state).toEqual({
-    withdrawAction: false,
-    moveToInCheckAction: false,
-    moveToInCheckForm: false,
-    recommendAction: false,
-    recommendToPayForm: false,
-    recommendToRejectForm: false,
-    authoriseAction: false,
-    authoriseForm: false,
-    rejectAction: false,
-    rejectForm: false,
-    updateStatusAction: false,
-    updateStatusForm: false,
-    updateDateOfVisitAction: false,
-    updateDateOfVisitForm: false,
-    updateEligiblePiiRedactionAction: false,
-    updateEligiblePiiRedactionForm: false,
-    updateVetRCVSNumberAction: false,
-    updateVetRCVSNumberForm: false,
-    updateVetsNameAction: false,
-    updateVetsNameForm: false,
+    expect(state).toEqual({
+      withdrawAction: false,
+      moveToInCheckAction: false,
+      moveToInCheckForm: false,
+      recommendAction: false,
+      recommendToPayForm: false,
+      recommendToRejectForm: false,
+      authoriseAction: false,
+      authoriseForm: false,
+      rejectAction: false,
+      rejectForm: false,
+      updateStatusAction: false,
+      updateStatusForm: false,
+      updateDateOfVisitAction: false,
+      updateDateOfVisitForm: false,
+      updateEligiblePiiRedactionAction: false,
+      updateEligiblePiiRedactionForm: false,
+      updateVetRCVSNumberAction: false,
+      updateVetRCVSNumberForm: false,
+      updateVetsNameAction: false,
+      updateVetsNameForm: false,
+    });
   });
-});
 
-test("status: in check, query: recommendToPay, user: admin", () => {
-  const request = {
-    query: {
-      recommendToPay: true,
-    },
-    auth: {
-      isAuthenticated: true,
-      credentials: {
-        account: { name: currentUser, username: "" },
-        scope: [administrator],
+  test("status: in check, query: recommendToPay, user: admin", () => {
+    const request = {
+      query: {
+        recommendToPay: true,
       },
-    },
-  };
-  const state = getClaimViewStates(request, status.IN_CHECK);
+      auth: {
+        isAuthenticated: true,
+        credentials: {
+          account: { name: currentUser, username: "" },
+          scope: [administrator],
+        },
+      },
+    };
+    const state = getClaimViewStates({ request, status: status.IN_CHECK });
 
-  expect(state).toEqual({
-    withdrawAction: false,
-    moveToInCheckAction: false,
-    moveToInCheckForm: false,
-    recommendAction: false,
-    recommendToPayForm: true,
-    recommendToRejectForm: false,
-    authoriseAction: false,
-    authoriseForm: false,
-    rejectAction: false,
-    rejectForm: false,
-    updateStatusAction: false,
-    updateStatusForm: false,
-    updateDateOfVisitAction: false,
-    updateDateOfVisitForm: false,
-    updateEligiblePiiRedactionAction: false,
-    updateEligiblePiiRedactionForm: false,
-    updateVetRCVSNumberAction: false,
-    updateVetRCVSNumberForm: false,
-    updateVetsNameAction: false,
-    updateVetsNameForm: false,
+    expect(state).toEqual({
+      withdrawAction: false,
+      moveToInCheckAction: false,
+      moveToInCheckForm: false,
+      recommendAction: false,
+      recommendToPayForm: true,
+      recommendToRejectForm: false,
+      authoriseAction: false,
+      authoriseForm: false,
+      rejectAction: false,
+      rejectForm: false,
+      updateStatusAction: false,
+      updateStatusForm: false,
+      updateDateOfVisitAction: false,
+      updateDateOfVisitForm: false,
+      updateEligiblePiiRedactionAction: false,
+      updateEligiblePiiRedactionForm: false,
+      updateVetRCVSNumberAction: false,
+      updateVetRCVSNumberForm: false,
+      updateVetsNameAction: false,
+      updateVetsNameForm: false,
+    });
   });
-});
 
-test("status: in check, query: recommendToPay, user: recommender", () => {
-  const request = {
-    query: {
-      recommendToPay: true,
-    },
-    auth: {
-      isAuthenticated: true,
-      credentials: {
-        account: { name: currentUser, username: "" },
-        scope: [recommender],
+  test("status: in check, query: recommendToPay, user: recommender", () => {
+    const request = {
+      query: {
+        recommendToPay: true,
       },
-    },
-  };
-  const state = getClaimViewStates(request, status.IN_CHECK);
+      auth: {
+        isAuthenticated: true,
+        credentials: {
+          account: { name: currentUser, username: "" },
+          scope: [recommender],
+        },
+      },
+    };
+    const state = getClaimViewStates({ request, status: status.IN_CHECK });
 
-  expect(state).toEqual({
-    withdrawAction: false,
-    moveToInCheckAction: false,
-    moveToInCheckForm: false,
-    recommendAction: false,
-    recommendToPayForm: true,
-    recommendToRejectForm: false,
-    authoriseAction: false,
-    authoriseForm: false,
-    rejectAction: false,
-    rejectForm: false,
-    updateStatusAction: false,
-    updateStatusForm: false,
-    updateDateOfVisitAction: false,
-    updateDateOfVisitForm: false,
-    updateEligiblePiiRedactionAction: false,
-    updateEligiblePiiRedactionForm: false,
-    updateVetRCVSNumberAction: false,
-    updateVetRCVSNumberForm: false,
-    updateVetsNameAction: false,
-    updateVetsNameForm: false,
+    expect(state).toEqual({
+      withdrawAction: false,
+      moveToInCheckAction: false,
+      moveToInCheckForm: false,
+      recommendAction: false,
+      recommendToPayForm: true,
+      recommendToRejectForm: false,
+      authoriseAction: false,
+      authoriseForm: false,
+      rejectAction: false,
+      rejectForm: false,
+      updateStatusAction: false,
+      updateStatusForm: false,
+      updateDateOfVisitAction: false,
+      updateDateOfVisitForm: false,
+      updateEligiblePiiRedactionAction: false,
+      updateEligiblePiiRedactionForm: false,
+      updateVetRCVSNumberAction: false,
+      updateVetRCVSNumberForm: false,
+      updateVetsNameAction: false,
+      updateVetsNameForm: false,
+    });
   });
-});
 
-test("status: in check, query: recommendToPay, user: authoriser", () => {
-  const request = {
-    query: {
-      recommendToPay: true,
-    },
-    auth: {
-      isAuthenticated: true,
-      credentials: {
-        account: { name: currentUser, username: "" },
-        scope: [authoriser],
+  test("status: in check, query: recommendToPay, user: authoriser", () => {
+    const request = {
+      query: {
+        recommendToPay: true,
       },
-    },
-  };
-  const state = getClaimViewStates(request, status.IN_CHECK);
+      auth: {
+        isAuthenticated: true,
+        credentials: {
+          account: { name: currentUser, username: "" },
+          scope: [authoriser],
+        },
+      },
+    };
+    const state = getClaimViewStates({ request, status: status.IN_CHECK });
 
-  expect(state).toEqual({
-    withdrawAction: false,
-    moveToInCheckAction: false,
-    moveToInCheckForm: false,
-    recommendAction: false,
-    recommendToPayForm: false,
-    recommendToRejectForm: false,
-    authoriseAction: false,
-    authoriseForm: false,
-    rejectAction: false,
-    rejectForm: false,
-    updateStatusAction: false,
-    updateStatusForm: false,
-    updateDateOfVisitAction: false,
-    updateDateOfVisitForm: false,
-    updateEligiblePiiRedactionAction: false,
-    updateEligiblePiiRedactionForm: false,
-    updateVetRCVSNumberAction: false,
-    updateVetRCVSNumberForm: false,
-    updateVetsNameAction: false,
-    updateVetsNameForm: false,
+    expect(state).toEqual({
+      withdrawAction: false,
+      moveToInCheckAction: false,
+      moveToInCheckForm: false,
+      recommendAction: false,
+      recommendToPayForm: false,
+      recommendToRejectForm: false,
+      authoriseAction: false,
+      authoriseForm: false,
+      rejectAction: false,
+      rejectForm: false,
+      updateStatusAction: false,
+      updateStatusForm: false,
+      updateDateOfVisitAction: false,
+      updateDateOfVisitForm: false,
+      updateEligiblePiiRedactionAction: false,
+      updateEligiblePiiRedactionForm: false,
+      updateVetRCVSNumberAction: false,
+      updateVetRCVSNumberForm: false,
+      updateVetsNameAction: false,
+      updateVetsNameForm: false,
+    });
   });
-});
 
-test("status: in check, query: recommendToReject, user: admin", () => {
-  const request = {
-    query: {
-      recommendToReject: true,
-    },
-    auth: {
-      isAuthenticated: true,
-      credentials: {
-        account: { name: currentUser, username: "" },
-        scope: [administrator],
+  test("status: in check, query: recommendToReject, user: admin", () => {
+    const request = {
+      query: {
+        recommendToReject: true,
       },
-    },
-  };
-  const state = getClaimViewStates(request, status.IN_CHECK);
+      auth: {
+        isAuthenticated: true,
+        credentials: {
+          account: { name: currentUser, username: "" },
+          scope: [administrator],
+        },
+      },
+    };
+    const state = getClaimViewStates({ request, status: status.IN_CHECK });
 
-  expect(state).toEqual({
-    withdrawAction: false,
-    moveToInCheckAction: false,
-    moveToInCheckForm: false,
-    recommendAction: false,
-    recommendToPayForm: false,
-    recommendToRejectForm: true,
-    authoriseAction: false,
-    authoriseForm: false,
-    rejectAction: false,
-    rejectForm: false,
-    updateStatusAction: false,
-    updateStatusForm: false,
-    updateDateOfVisitAction: false,
-    updateDateOfVisitForm: false,
-    updateEligiblePiiRedactionAction: false,
-    updateEligiblePiiRedactionForm: false,
-    updateVetRCVSNumberAction: false,
-    updateVetRCVSNumberForm: false,
-    updateVetsNameAction: false,
-    updateVetsNameForm: false,
+    expect(state).toEqual({
+      withdrawAction: false,
+      moveToInCheckAction: false,
+      moveToInCheckForm: false,
+      recommendAction: false,
+      recommendToPayForm: false,
+      recommendToRejectForm: true,
+      authoriseAction: false,
+      authoriseForm: false,
+      rejectAction: false,
+      rejectForm: false,
+      updateStatusAction: false,
+      updateStatusForm: false,
+      updateDateOfVisitAction: false,
+      updateDateOfVisitForm: false,
+      updateEligiblePiiRedactionAction: false,
+      updateEligiblePiiRedactionForm: false,
+      updateVetRCVSNumberAction: false,
+      updateVetRCVSNumberForm: false,
+      updateVetsNameAction: false,
+      updateVetsNameForm: false,
+    });
   });
-});
 
-test("status: in check, query: recommendToReject, user: recommender", () => {
-  const request = {
-    query: {
-      recommendToReject: true,
-    },
-    auth: {
-      isAuthenticated: true,
-      credentials: {
-        account: { name: currentUser, username: "" },
-        scope: [recommender],
+  test("status: in check, query: recommendToReject, user: recommender", () => {
+    const request = {
+      query: {
+        recommendToReject: true,
       },
-    },
-  };
-  const state = getClaimViewStates(request, status.IN_CHECK);
+      auth: {
+        isAuthenticated: true,
+        credentials: {
+          account: { name: currentUser, username: "" },
+          scope: [recommender],
+        },
+      },
+    };
+    const state = getClaimViewStates({ request, status: status.IN_CHECK });
 
-  expect(state).toEqual({
-    withdrawAction: false,
-    moveToInCheckAction: false,
-    moveToInCheckForm: false,
-    recommendAction: false,
-    recommendToPayForm: false,
-    recommendToRejectForm: true,
-    authoriseAction: false,
-    authoriseForm: false,
-    rejectAction: false,
-    rejectForm: false,
-    updateStatusAction: false,
-    updateStatusForm: false,
-    updateDateOfVisitAction: false,
-    updateDateOfVisitForm: false,
-    updateEligiblePiiRedactionAction: false,
-    updateEligiblePiiRedactionForm: false,
-    updateVetRCVSNumberAction: false,
-    updateVetRCVSNumberForm: false,
-    updateVetsNameAction: false,
-    updateVetsNameForm: false,
+    expect(state).toEqual({
+      withdrawAction: false,
+      moveToInCheckAction: false,
+      moveToInCheckForm: false,
+      recommendAction: false,
+      recommendToPayForm: false,
+      recommendToRejectForm: true,
+      authoriseAction: false,
+      authoriseForm: false,
+      rejectAction: false,
+      rejectForm: false,
+      updateStatusAction: false,
+      updateStatusForm: false,
+      updateDateOfVisitAction: false,
+      updateDateOfVisitForm: false,
+      updateEligiblePiiRedactionAction: false,
+      updateEligiblePiiRedactionForm: false,
+      updateVetRCVSNumberAction: false,
+      updateVetRCVSNumberForm: false,
+      updateVetsNameAction: false,
+      updateVetsNameForm: false,
+    });
   });
-});
 
-test("status: in check, query: recommendToReject, user: authoriser", () => {
-  const request = {
-    query: {
-      recommendToReject: true,
-    },
-    auth: {
-      isAuthenticated: true,
-      credentials: {
-        account: { name: currentUser, username: "" },
-        scope: [authoriser],
+  test("status: in check, query: recommendToReject, user: authoriser", () => {
+    const request = {
+      query: {
+        recommendToReject: true,
       },
-    },
-  };
-  const state = getClaimViewStates(request, status.IN_CHECK);
+      auth: {
+        isAuthenticated: true,
+        credentials: {
+          account: { name: currentUser, username: "" },
+          scope: [authoriser],
+        },
+      },
+    };
+    const state = getClaimViewStates({ request, status: status.IN_CHECK });
 
-  expect(state).toEqual({
-    withdrawAction: false,
-    moveToInCheckAction: false,
-    moveToInCheckForm: false,
-    recommendAction: false,
-    recommendToPayForm: false,
-    recommendToRejectForm: false,
-    authoriseAction: false,
-    authoriseForm: false,
-    rejectAction: false,
-    rejectForm: false,
-    updateStatusAction: false,
-    updateStatusForm: false,
-    updateDateOfVisitAction: false,
-    updateDateOfVisitForm: false,
-    updateEligiblePiiRedactionAction: false,
-    updateEligiblePiiRedactionForm: false,
-    updateVetRCVSNumberAction: false,
-    updateVetRCVSNumberForm: false,
-    updateVetsNameAction: false,
-    updateVetsNameForm: false,
+    expect(state).toEqual({
+      withdrawAction: false,
+      moveToInCheckAction: false,
+      moveToInCheckForm: false,
+      recommendAction: false,
+      recommendToPayForm: false,
+      recommendToRejectForm: false,
+      authoriseAction: false,
+      authoriseForm: false,
+      rejectAction: false,
+      rejectForm: false,
+      updateStatusAction: false,
+      updateStatusForm: false,
+      updateDateOfVisitAction: false,
+      updateDateOfVisitForm: false,
+      updateEligiblePiiRedactionAction: false,
+      updateEligiblePiiRedactionForm: false,
+      updateVetRCVSNumberAction: false,
+      updateVetRCVSNumberForm: false,
+      updateVetsNameAction: false,
+      updateVetsNameForm: false,
+    });
   });
-});
 
-test("status: in recommended to pay, user: admin, recommender: different person", () => {
-  const request = {
-    query: {
-      approve: false,
-    },
-    auth: {
-      isAuthenticated: true,
-      credentials: {
-        account: { name: currentUser, username: "" },
-        scope: [administrator],
+  test("status: in recommended to pay, user: admin, recommender: different person", () => {
+    const request = {
+      query: {
+        approve: false,
       },
-    },
-  };
-  const currentStatusEvent = {
-    updatedBy: "someone else",
-  };
-  const state = getClaimViewStates(request, status.RECOMMENDED_TO_PAY, currentStatusEvent);
+      auth: {
+        isAuthenticated: true,
+        credentials: {
+          account: { name: currentUser, username: "" },
+          scope: [administrator],
+        },
+      },
+    };
+    const currentStatusEvent = {
+      updatedBy: "someone else",
+    };
+    const state = getClaimViewStates({
+      request,
+      status: status.RECOMMENDED_TO_PAY,
+      currentStatusEvent,
+    });
 
-  expect(state).toEqual({
-    withdrawAction: false,
-    moveToInCheckAction: false,
-    moveToInCheckForm: false,
-    recommendAction: false,
-    recommendToPayForm: false,
-    recommendToRejectForm: false,
-    authoriseAction: true,
-    authoriseForm: false,
-    rejectAction: false,
-    rejectForm: false,
-    updateStatusAction: false,
-    updateStatusForm: false,
-    updateDateOfVisitAction: false,
-    updateDateOfVisitForm: false,
-    updateEligiblePiiRedactionAction: false,
-    updateEligiblePiiRedactionForm: false,
-    updateVetRCVSNumberAction: false,
-    updateVetRCVSNumberForm: false,
-    updateVetsNameAction: false,
-    updateVetsNameForm: false,
+    expect(state).toEqual({
+      withdrawAction: false,
+      moveToInCheckAction: false,
+      moveToInCheckForm: false,
+      recommendAction: false,
+      recommendToPayForm: false,
+      recommendToRejectForm: false,
+      authoriseAction: true,
+      authoriseForm: false,
+      rejectAction: false,
+      rejectForm: false,
+      updateStatusAction: false,
+      updateStatusForm: false,
+      updateDateOfVisitAction: false,
+      updateDateOfVisitForm: false,
+      updateEligiblePiiRedactionAction: false,
+      updateEligiblePiiRedactionForm: false,
+      updateVetRCVSNumberAction: false,
+      updateVetRCVSNumberForm: false,
+      updateVetsNameAction: false,
+      updateVetsNameForm: false,
+    });
   });
-});
 
-test("status: in recommended to pay, user: admin, recommender: same person", () => {
-  const request = {
-    query: {
-      approve: false,
-    },
-    auth: {
-      isAuthenticated: true,
-      credentials: {
-        account: { name: currentUser, username: "" },
-        scope: [administrator],
+  test("status: in recommended to pay, user: admin, recommender: same person", () => {
+    const request = {
+      query: {
+        approve: false,
       },
-    },
-  };
-  const currentStatusEvent = {
-    updatedBy: currentUser,
-  };
-  const state = getClaimViewStates(request, status.RECOMMENDED_TO_PAY, currentStatusEvent);
+      auth: {
+        isAuthenticated: true,
+        credentials: {
+          account: { name: currentUser, username: "" },
+          scope: [administrator],
+        },
+      },
+    };
+    const currentStatusEvent = {
+      updatedBy: currentUser,
+    };
+    const state = getClaimViewStates({
+      request,
+      status: status.RECOMMENDED_TO_PAY,
+      currentStatusEvent,
+    });
 
-  expect(state).toEqual({
-    withdrawAction: false,
-    moveToInCheckAction: false,
-    moveToInCheckForm: false,
-    recommendAction: false,
-    recommendToPayForm: false,
-    recommendToRejectForm: false,
-    authoriseAction: false,
-    authoriseForm: false,
-    rejectAction: false,
-    rejectForm: false,
-    updateStatusAction: false,
-    updateStatusForm: false,
-    updateDateOfVisitAction: false,
-    updateDateOfVisitForm: false,
-    updateEligiblePiiRedactionAction: false,
-    updateEligiblePiiRedactionForm: false,
-    updateVetRCVSNumberAction: false,
-    updateVetRCVSNumberForm: false,
-    updateVetsNameAction: false,
-    updateVetsNameForm: false,
+    expect(state).toEqual({
+      withdrawAction: false,
+      moveToInCheckAction: false,
+      moveToInCheckForm: false,
+      recommendAction: false,
+      recommendToPayForm: false,
+      recommendToRejectForm: false,
+      authoriseAction: false,
+      authoriseForm: false,
+      rejectAction: false,
+      rejectForm: false,
+      updateStatusAction: false,
+      updateStatusForm: false,
+      updateDateOfVisitAction: false,
+      updateDateOfVisitForm: false,
+      updateEligiblePiiRedactionAction: false,
+      updateEligiblePiiRedactionForm: false,
+      updateVetRCVSNumberAction: false,
+      updateVetRCVSNumberForm: false,
+      updateVetsNameAction: false,
+      updateVetsNameForm: false,
+    });
   });
-});
 
-test("status: in recommended to pay, user: recommender, recommender: different person", () => {
-  const request = {
-    query: {
-      approve: false,
-    },
-    auth: {
-      isAuthenticated: true,
-      credentials: {
-        account: { name: currentUser, username: "" },
-        scope: [recommender],
+  test("status: in recommended to pay, user: recommender, recommender: different person", () => {
+    const request = {
+      query: {
+        approve: false,
       },
-    },
-  };
-  const currentStatusEvent = {
-    updatedBy: "someone else",
-  };
-  const state = getClaimViewStates(request, status.RECOMMENDED_TO_PAY, currentStatusEvent);
+      auth: {
+        isAuthenticated: true,
+        credentials: {
+          account: { name: currentUser, username: "" },
+          scope: [recommender],
+        },
+      },
+    };
+    const currentStatusEvent = {
+      updatedBy: "someone else",
+    };
+    const state = getClaimViewStates({
+      request,
+      status: status.RECOMMENDED_TO_PAY,
+      currentStatusEvent,
+    });
 
-  expect(state).toEqual({
-    withdrawAction: false,
-    moveToInCheckAction: false,
-    moveToInCheckForm: false,
-    recommendAction: false,
-    recommendToPayForm: false,
-    recommendToRejectForm: false,
-    authoriseAction: false,
-    authoriseForm: false,
-    rejectAction: false,
-    rejectForm: false,
-    updateStatusAction: false,
-    updateStatusForm: false,
-    updateDateOfVisitAction: false,
-    updateDateOfVisitForm: false,
-    updateEligiblePiiRedactionAction: false,
-    updateEligiblePiiRedactionForm: false,
-    updateVetRCVSNumberAction: false,
-    updateVetRCVSNumberForm: false,
-    updateVetsNameAction: false,
-    updateVetsNameForm: false,
+    expect(state).toEqual({
+      withdrawAction: false,
+      moveToInCheckAction: false,
+      moveToInCheckForm: false,
+      recommendAction: false,
+      recommendToPayForm: false,
+      recommendToRejectForm: false,
+      authoriseAction: false,
+      authoriseForm: false,
+      rejectAction: false,
+      rejectForm: false,
+      updateStatusAction: false,
+      updateStatusForm: false,
+      updateDateOfVisitAction: false,
+      updateDateOfVisitForm: false,
+      updateEligiblePiiRedactionAction: false,
+      updateEligiblePiiRedactionForm: false,
+      updateVetRCVSNumberAction: false,
+      updateVetRCVSNumberForm: false,
+      updateVetsNameAction: false,
+      updateVetsNameForm: false,
+    });
   });
-});
 
-test("status: in recommended to pay, user: authoriser, recommender: different person", () => {
-  const request = {
-    query: {
-      approve: false,
-    },
-    auth: {
-      isAuthenticated: true,
-      credentials: {
-        account: { name: currentUser, username: "" },
-        scope: [authoriser],
+  test("status: in recommended to pay, user: authoriser, recommender: different person", () => {
+    const request = {
+      query: {
+        approve: false,
       },
-    },
-  };
-  const currentStatusEvent = {
-    updatedBy: "someone else",
-  };
-  const state = getClaimViewStates(request, status.RECOMMENDED_TO_PAY, currentStatusEvent);
+      auth: {
+        isAuthenticated: true,
+        credentials: {
+          account: { name: currentUser, username: "" },
+          scope: [authoriser],
+        },
+      },
+    };
+    const currentStatusEvent = {
+      updatedBy: "someone else",
+    };
+    const state = getClaimViewStates({
+      request,
+      status: status.RECOMMENDED_TO_PAY,
+      currentStatusEvent,
+    });
 
-  expect(state).toEqual({
-    withdrawAction: false,
-    moveToInCheckAction: false,
-    moveToInCheckForm: false,
-    recommendAction: false,
-    recommendToPayForm: false,
-    recommendToRejectForm: false,
-    authoriseAction: true,
-    authoriseForm: false,
-    rejectAction: false,
-    rejectForm: false,
-    updateStatusAction: false,
-    updateStatusForm: false,
-    updateDateOfVisitAction: false,
-    updateDateOfVisitForm: false,
-    updateEligiblePiiRedactionAction: false,
-    updateEligiblePiiRedactionForm: false,
-    updateVetRCVSNumberAction: false,
-    updateVetRCVSNumberForm: false,
-    updateVetsNameAction: false,
-    updateVetsNameForm: false,
+    expect(state).toEqual({
+      withdrawAction: false,
+      moveToInCheckAction: false,
+      moveToInCheckForm: false,
+      recommendAction: false,
+      recommendToPayForm: false,
+      recommendToRejectForm: false,
+      authoriseAction: true,
+      authoriseForm: false,
+      rejectAction: false,
+      rejectForm: false,
+      updateStatusAction: false,
+      updateStatusForm: false,
+      updateDateOfVisitAction: false,
+      updateDateOfVisitForm: false,
+      updateEligiblePiiRedactionAction: false,
+      updateEligiblePiiRedactionForm: false,
+      updateVetRCVSNumberAction: false,
+      updateVetRCVSNumberForm: false,
+      updateVetsNameAction: false,
+      updateVetsNameForm: false,
+    });
   });
-});
 
-test("status: in recommended to pay, query: approve, user: admin, recommender: different person", () => {
-  const request = {
-    query: {
-      approve: true,
-    },
-    auth: {
-      isAuthenticated: true,
-      credentials: {
-        account: { name: currentUser, username: "" },
-        scope: [administrator],
+  test("status: in recommended to pay, query: approve, user: admin, recommender: different person", () => {
+    const request = {
+      query: {
+        approve: true,
       },
-    },
-  };
-  const currentStatusEvent = {
-    updatedBy: "someone else",
-  };
-  const state = getClaimViewStates(request, status.RECOMMENDED_TO_PAY, currentStatusEvent);
+      auth: {
+        isAuthenticated: true,
+        credentials: {
+          account: { name: currentUser, username: "" },
+          scope: [administrator],
+        },
+      },
+    };
+    const currentStatusEvent = {
+      updatedBy: "someone else",
+    };
+    const state = getClaimViewStates({
+      request,
+      status: status.RECOMMENDED_TO_PAY,
+      currentStatusEvent,
+    });
 
-  expect(state).toEqual({
-    withdrawAction: false,
-    moveToInCheckAction: false,
-    moveToInCheckForm: false,
-    recommendAction: false,
-    recommendToPayForm: false,
-    recommendToRejectForm: false,
-    authoriseAction: false,
-    authoriseForm: true,
-    rejectAction: false,
-    rejectForm: false,
-    updateStatusAction: false,
-    updateStatusForm: false,
-    updateDateOfVisitAction: false,
-    updateDateOfVisitForm: false,
-    updateEligiblePiiRedactionAction: false,
-    updateEligiblePiiRedactionForm: false,
-    updateVetRCVSNumberAction: false,
-    updateVetRCVSNumberForm: false,
-    updateVetsNameAction: false,
-    updateVetsNameForm: false,
+    expect(state).toEqual({
+      withdrawAction: false,
+      moveToInCheckAction: false,
+      moveToInCheckForm: false,
+      recommendAction: false,
+      recommendToPayForm: false,
+      recommendToRejectForm: false,
+      authoriseAction: false,
+      authoriseForm: true,
+      rejectAction: false,
+      rejectForm: false,
+      updateStatusAction: false,
+      updateStatusForm: false,
+      updateDateOfVisitAction: false,
+      updateDateOfVisitForm: false,
+      updateEligiblePiiRedactionAction: false,
+      updateEligiblePiiRedactionForm: false,
+      updateVetRCVSNumberAction: false,
+      updateVetRCVSNumberForm: false,
+      updateVetsNameAction: false,
+      updateVetsNameForm: false,
+    });
   });
-});
 
-test("status: in recommended to pay, query: approve, user: recommender, recommender: different person", () => {
-  const request = {
-    query: {
-      approve: true,
-    },
-    auth: {
-      isAuthenticated: true,
-      credentials: {
-        account: { name: currentUser, username: "" },
-        scope: [recommender],
+  test("status: in recommended to pay, query: approve, user: recommender, recommender: different person", () => {
+    const request = {
+      query: {
+        approve: true,
       },
-    },
-  };
-  const currentStatusEvent = {
-    updatedBy: "someone else",
-  };
-  const state = getClaimViewStates(request, status.RECOMMENDED_TO_PAY, currentStatusEvent);
+      auth: {
+        isAuthenticated: true,
+        credentials: {
+          account: { name: currentUser, username: "" },
+          scope: [recommender],
+        },
+      },
+    };
+    const currentStatusEvent = {
+      updatedBy: "someone else",
+    };
+    const state = getClaimViewStates({
+      request,
+      status: status.RECOMMENDED_TO_PAY,
+      currentStatusEvent,
+    });
 
-  expect(state).toEqual({
-    withdrawAction: false,
-    moveToInCheckAction: false,
-    moveToInCheckForm: false,
-    recommendAction: false,
-    recommendToPayForm: false,
-    recommendToRejectForm: false,
-    authoriseAction: false,
-    authoriseForm: false,
-    rejectAction: false,
-    rejectForm: false,
-    updateStatusAction: false,
-    updateStatusForm: false,
-    updateDateOfVisitAction: false,
-    updateDateOfVisitForm: false,
-    updateEligiblePiiRedactionAction: false,
-    updateEligiblePiiRedactionForm: false,
-    updateVetRCVSNumberAction: false,
-    updateVetRCVSNumberForm: false,
-    updateVetsNameAction: false,
-    updateVetsNameForm: false,
+    expect(state).toEqual({
+      withdrawAction: false,
+      moveToInCheckAction: false,
+      moveToInCheckForm: false,
+      recommendAction: false,
+      recommendToPayForm: false,
+      recommendToRejectForm: false,
+      authoriseAction: false,
+      authoriseForm: false,
+      rejectAction: false,
+      rejectForm: false,
+      updateStatusAction: false,
+      updateStatusForm: false,
+      updateDateOfVisitAction: false,
+      updateDateOfVisitForm: false,
+      updateEligiblePiiRedactionAction: false,
+      updateEligiblePiiRedactionForm: false,
+      updateVetRCVSNumberAction: false,
+      updateVetRCVSNumberForm: false,
+      updateVetsNameAction: false,
+      updateVetsNameForm: false,
+    });
   });
-});
 
-test("status: in recommended to pay, query: approve, user: authoriser, recommender: different person", () => {
-  const request = {
-    query: {
-      approve: true,
-    },
-    auth: {
-      isAuthenticated: true,
-      credentials: {
-        account: { name: currentUser, username: "" },
-        scope: [authoriser],
+  test("status: in recommended to pay, query: approve, user: authoriser, recommender: different person", () => {
+    const request = {
+      query: {
+        approve: true,
       },
-    },
-  };
-  const currentStatusEvent = {
-    updatedBy: "someone else",
-  };
-  const state = getClaimViewStates(request, status.RECOMMENDED_TO_PAY, currentStatusEvent);
+      auth: {
+        isAuthenticated: true,
+        credentials: {
+          account: { name: currentUser, username: "" },
+          scope: [authoriser],
+        },
+      },
+    };
+    const currentStatusEvent = {
+      updatedBy: "someone else",
+    };
+    const state = getClaimViewStates({
+      request,
+      status: status.RECOMMENDED_TO_PAY,
+      currentStatusEvent,
+    });
 
-  expect(state).toEqual({
-    withdrawAction: false,
-    moveToInCheckAction: false,
-    moveToInCheckForm: false,
-    recommendAction: false,
-    recommendToPayForm: false,
-    recommendToRejectForm: false,
-    authoriseAction: false,
-    authoriseForm: true,
-    rejectAction: false,
-    rejectForm: false,
-    updateStatusAction: false,
-    updateStatusForm: false,
-    updateDateOfVisitAction: false,
-    updateDateOfVisitForm: false,
-    updateEligiblePiiRedactionAction: false,
-    updateEligiblePiiRedactionForm: false,
-    updateVetRCVSNumberAction: false,
-    updateVetRCVSNumberForm: false,
-    updateVetsNameAction: false,
-    updateVetsNameForm: false,
+    expect(state).toEqual({
+      withdrawAction: false,
+      moveToInCheckAction: false,
+      moveToInCheckForm: false,
+      recommendAction: false,
+      recommendToPayForm: false,
+      recommendToRejectForm: false,
+      authoriseAction: false,
+      authoriseForm: true,
+      rejectAction: false,
+      rejectForm: false,
+      updateStatusAction: false,
+      updateStatusForm: false,
+      updateDateOfVisitAction: false,
+      updateDateOfVisitForm: false,
+      updateEligiblePiiRedactionAction: false,
+      updateEligiblePiiRedactionForm: false,
+      updateVetRCVSNumberAction: false,
+      updateVetRCVSNumberForm: false,
+      updateVetsNameAction: false,
+      updateVetsNameForm: false,
+    });
   });
-});
 
-test("status: in recommended to reject, user: admin, recommender: different person", () => {
-  const request = {
-    query: {
-      reject: false,
-    },
-    auth: {
-      isAuthenticated: true,
-      credentials: {
-        account: { name: currentUser, username: "" },
-        scope: [administrator],
+  test("status: in recommended to reject, user: admin, recommender: different person", () => {
+    const request = {
+      query: {
+        reject: false,
       },
-    },
-  };
-  const currentStatusEvent = {
-    updatedBy: "someone else",
-  };
-  const state = getClaimViewStates(request, status.RECOMMENDED_TO_REJECT, currentStatusEvent);
+      auth: {
+        isAuthenticated: true,
+        credentials: {
+          account: { name: currentUser, username: "" },
+          scope: [administrator],
+        },
+      },
+    };
+    const currentStatusEvent = {
+      updatedBy: "someone else",
+    };
+    const state = getClaimViewStates({
+      request,
+      status: status.RECOMMENDED_TO_REJECT,
+      currentStatusEvent,
+    });
 
-  expect(state).toEqual({
-    withdrawAction: false,
-    moveToInCheckAction: false,
-    moveToInCheckForm: false,
-    recommendAction: false,
-    recommendToPayForm: false,
-    recommendToRejectForm: false,
-    authoriseAction: false,
-    authoriseForm: false,
-    rejectAction: true,
-    rejectForm: false,
-    updateStatusAction: false,
-    updateStatusForm: false,
-    updateDateOfVisitAction: false,
-    updateDateOfVisitForm: false,
-    updateEligiblePiiRedactionAction: false,
-    updateEligiblePiiRedactionForm: false,
-    updateVetRCVSNumberAction: false,
-    updateVetRCVSNumberForm: false,
-    updateVetsNameAction: false,
-    updateVetsNameForm: false,
+    expect(state).toEqual({
+      withdrawAction: false,
+      moveToInCheckAction: false,
+      moveToInCheckForm: false,
+      recommendAction: false,
+      recommendToPayForm: false,
+      recommendToRejectForm: false,
+      authoriseAction: false,
+      authoriseForm: false,
+      rejectAction: true,
+      rejectForm: false,
+      updateStatusAction: false,
+      updateStatusForm: false,
+      updateDateOfVisitAction: false,
+      updateDateOfVisitForm: false,
+      updateEligiblePiiRedactionAction: false,
+      updateEligiblePiiRedactionForm: false,
+      updateVetRCVSNumberAction: false,
+      updateVetRCVSNumberForm: false,
+      updateVetsNameAction: false,
+      updateVetsNameForm: false,
+    });
   });
-});
 
-test("status: in recommended to reject, user: admin, recommender: same person", () => {
-  const request = {
-    query: {
-      reject: false,
-    },
-    auth: {
-      isAuthenticated: true,
-      credentials: {
-        account: { name: currentUser, username: "" },
-        scope: [administrator],
+  test("status: in recommended to reject, user: admin, recommender: same person", () => {
+    const request = {
+      query: {
+        reject: false,
       },
-    },
-  };
-  const currentStatusEvent = {
-    updatedBy: currentUser,
-  };
-  const state = getClaimViewStates(request, status.RECOMMENDED_TO_REJECT, currentStatusEvent);
+      auth: {
+        isAuthenticated: true,
+        credentials: {
+          account: { name: currentUser, username: "" },
+          scope: [administrator],
+        },
+      },
+    };
+    const currentStatusEvent = {
+      updatedBy: currentUser,
+    };
+    const state = getClaimViewStates({
+      request,
+      status: status.RECOMMENDED_TO_REJECT,
+      currentStatusEvent,
+    });
 
-  expect(state).toEqual({
-    withdrawAction: false,
-    moveToInCheckAction: false,
-    moveToInCheckForm: false,
-    recommendAction: false,
-    recommendToPayForm: false,
-    recommendToRejectForm: false,
-    authoriseAction: false,
-    authoriseForm: false,
-    rejectAction: false,
-    rejectForm: false,
-    updateStatusAction: false,
-    updateStatusForm: false,
-    updateDateOfVisitAction: false,
-    updateDateOfVisitForm: false,
-    updateEligiblePiiRedactionAction: false,
-    updateEligiblePiiRedactionForm: false,
-    updateVetRCVSNumberAction: false,
-    updateVetRCVSNumberForm: false,
-    updateVetsNameAction: false,
-    updateVetsNameForm: false,
+    expect(state).toEqual({
+      withdrawAction: false,
+      moveToInCheckAction: false,
+      moveToInCheckForm: false,
+      recommendAction: false,
+      recommendToPayForm: false,
+      recommendToRejectForm: false,
+      authoriseAction: false,
+      authoriseForm: false,
+      rejectAction: false,
+      rejectForm: false,
+      updateStatusAction: false,
+      updateStatusForm: false,
+      updateDateOfVisitAction: false,
+      updateDateOfVisitForm: false,
+      updateEligiblePiiRedactionAction: false,
+      updateEligiblePiiRedactionForm: false,
+      updateVetRCVSNumberAction: false,
+      updateVetRCVSNumberForm: false,
+      updateVetsNameAction: false,
+      updateVetsNameForm: false,
+    });
   });
-});
 
-test("status: in recommended to reject, user: recommender, recommender: different person", () => {
-  const request = {
-    query: {
-      reject: false,
-    },
-    auth: {
-      isAuthenticated: true,
-      credentials: {
-        account: { name: currentUser, username: "" },
-        scope: [recommender],
+  test("status: in recommended to reject, user: recommender, recommender: different person", () => {
+    const request = {
+      query: {
+        reject: false,
       },
-    },
-  };
-  const currentStatusEvent = {
-    updatedBy: "someone else",
-  };
-  const state = getClaimViewStates(request, status.RECOMMENDED_TO_REJECT, currentStatusEvent);
+      auth: {
+        isAuthenticated: true,
+        credentials: {
+          account: { name: currentUser, username: "" },
+          scope: [recommender],
+        },
+      },
+    };
+    const currentStatusEvent = {
+      updatedBy: "someone else",
+    };
+    const state = getClaimViewStates({
+      request,
+      status: status.RECOMMENDED_TO_REJECT,
+      currentStatusEvent,
+    });
 
-  expect(state).toEqual({
-    withdrawAction: false,
-    moveToInCheckAction: false,
-    moveToInCheckForm: false,
-    recommendAction: false,
-    recommendToPayForm: false,
-    recommendToRejectForm: false,
-    authoriseAction: false,
-    authoriseForm: false,
-    rejectAction: false,
-    rejectForm: false,
-    updateStatusAction: false,
-    updateStatusForm: false,
-    updateDateOfVisitAction: false,
-    updateDateOfVisitForm: false,
-    updateEligiblePiiRedactionAction: false,
-    updateEligiblePiiRedactionForm: false,
-    updateVetRCVSNumberAction: false,
-    updateVetRCVSNumberForm: false,
-    updateVetsNameAction: false,
-    updateVetsNameForm: false,
+    expect(state).toEqual({
+      withdrawAction: false,
+      moveToInCheckAction: false,
+      moveToInCheckForm: false,
+      recommendAction: false,
+      recommendToPayForm: false,
+      recommendToRejectForm: false,
+      authoriseAction: false,
+      authoriseForm: false,
+      rejectAction: false,
+      rejectForm: false,
+      updateStatusAction: false,
+      updateStatusForm: false,
+      updateDateOfVisitAction: false,
+      updateDateOfVisitForm: false,
+      updateEligiblePiiRedactionAction: false,
+      updateEligiblePiiRedactionForm: false,
+      updateVetRCVSNumberAction: false,
+      updateVetRCVSNumberForm: false,
+      updateVetsNameAction: false,
+      updateVetsNameForm: false,
+    });
   });
-});
 
-test("status: in recommended to reject, user: authoriser, recommender: different person", () => {
-  const request = {
-    query: {
-      reject: false,
-    },
-    auth: {
-      isAuthenticated: true,
-      credentials: {
-        account: { name: currentUser, username: "" },
-        scope: [authoriser],
+  test("status: in recommended to reject, user: authoriser, recommender: different person", () => {
+    const request = {
+      query: {
+        reject: false,
       },
-    },
-  };
-  const currentStatusEvent = {
-    updatedBy: "someone else",
-  };
-  const state = getClaimViewStates(request, status.RECOMMENDED_TO_REJECT, currentStatusEvent);
+      auth: {
+        isAuthenticated: true,
+        credentials: {
+          account: { name: currentUser, username: "" },
+          scope: [authoriser],
+        },
+      },
+    };
+    const currentStatusEvent = {
+      updatedBy: "someone else",
+    };
+    const state = getClaimViewStates({
+      request,
+      status: status.RECOMMENDED_TO_REJECT,
+      currentStatusEvent,
+    });
 
-  expect(state).toEqual({
-    withdrawAction: false,
-    moveToInCheckAction: false,
-    moveToInCheckForm: false,
-    recommendAction: false,
-    recommendToPayForm: false,
-    recommendToRejectForm: false,
-    authoriseAction: false,
-    authoriseForm: false,
-    rejectAction: true,
-    rejectForm: false,
-    updateStatusAction: false,
-    updateStatusForm: false,
-    updateDateOfVisitAction: false,
-    updateDateOfVisitForm: false,
-    updateEligiblePiiRedactionAction: false,
-    updateEligiblePiiRedactionForm: false,
-    updateVetRCVSNumberAction: false,
-    updateVetRCVSNumberForm: false,
-    updateVetsNameAction: false,
-    updateVetsNameForm: false,
+    expect(state).toEqual({
+      withdrawAction: false,
+      moveToInCheckAction: false,
+      moveToInCheckForm: false,
+      recommendAction: false,
+      recommendToPayForm: false,
+      recommendToRejectForm: false,
+      authoriseAction: false,
+      authoriseForm: false,
+      rejectAction: true,
+      rejectForm: false,
+      updateStatusAction: false,
+      updateStatusForm: false,
+      updateDateOfVisitAction: false,
+      updateDateOfVisitForm: false,
+      updateEligiblePiiRedactionAction: false,
+      updateEligiblePiiRedactionForm: false,
+      updateVetRCVSNumberAction: false,
+      updateVetRCVSNumberForm: false,
+      updateVetsNameAction: false,
+      updateVetsNameForm: false,
+    });
   });
-});
 
-test("status: in recommended to reject, query: reject, user: admin, recommender: different person", () => {
-  const request = {
-    query: {
-      reject: true,
-    },
-    auth: {
-      isAuthenticated: true,
-      credentials: {
-        account: { name: currentUser, username: "" },
-        scope: [administrator],
+  test("status: in recommended to reject, query: reject, user: admin, recommender: different person", () => {
+    const request = {
+      query: {
+        reject: true,
       },
-    },
-  };
-  const currentStatusEvent = {
-    updatedBy: "someone else",
-  };
-  const state = getClaimViewStates(request, status.RECOMMENDED_TO_REJECT, currentStatusEvent);
+      auth: {
+        isAuthenticated: true,
+        credentials: {
+          account: { name: currentUser, username: "" },
+          scope: [administrator],
+        },
+      },
+    };
+    const currentStatusEvent = {
+      updatedBy: "someone else",
+    };
+    const state = getClaimViewStates({
+      request,
+      status: status.RECOMMENDED_TO_REJECT,
+      currentStatusEvent,
+    });
 
-  expect(state).toEqual({
-    withdrawAction: false,
-    moveToInCheckAction: false,
-    moveToInCheckForm: false,
-    recommendAction: false,
-    recommendToPayForm: false,
-    recommendToRejectForm: false,
-    authoriseAction: false,
-    authoriseForm: false,
-    rejectAction: false,
-    rejectForm: true,
-    updateStatusAction: false,
-    updateStatusForm: false,
-    updateDateOfVisitAction: false,
-    updateDateOfVisitForm: false,
-    updateEligiblePiiRedactionAction: false,
-    updateEligiblePiiRedactionForm: false,
-    updateVetRCVSNumberAction: false,
-    updateVetRCVSNumberForm: false,
-    updateVetsNameAction: false,
-    updateVetsNameForm: false,
+    expect(state).toEqual({
+      withdrawAction: false,
+      moveToInCheckAction: false,
+      moveToInCheckForm: false,
+      recommendAction: false,
+      recommendToPayForm: false,
+      recommendToRejectForm: false,
+      authoriseAction: false,
+      authoriseForm: false,
+      rejectAction: false,
+      rejectForm: true,
+      updateStatusAction: false,
+      updateStatusForm: false,
+      updateDateOfVisitAction: false,
+      updateDateOfVisitForm: false,
+      updateEligiblePiiRedactionAction: false,
+      updateEligiblePiiRedactionForm: false,
+      updateVetRCVSNumberAction: false,
+      updateVetRCVSNumberForm: false,
+      updateVetsNameAction: false,
+      updateVetsNameForm: false,
+    });
   });
-});
 
-test("status: in recommended to reject, query: reject, user: admin, recommender: same person", () => {
-  const request = {
-    query: {
-      reject: true,
-    },
-    auth: {
-      isAuthenticated: true,
-      credentials: {
-        account: { name: currentUser, username: "" },
-        scope: [administrator],
+  test("status: in recommended to reject, query: reject, user: admin, recommender: same person", () => {
+    const request = {
+      query: {
+        reject: true,
       },
-    },
-  };
-  const currentStatusEvent = {
-    updatedBy: currentUser,
-  };
-  const state = getClaimViewStates(request, status.RECOMMENDED_TO_REJECT, currentStatusEvent);
+      auth: {
+        isAuthenticated: true,
+        credentials: {
+          account: { name: currentUser, username: "" },
+          scope: [administrator],
+        },
+      },
+    };
+    const currentStatusEvent = {
+      updatedBy: currentUser,
+    };
+    const state = getClaimViewStates({
+      request,
+      status: status.RECOMMENDED_TO_REJECT,
+      currentStatusEvent,
+    });
 
-  expect(state).toEqual({
-    withdrawAction: false,
-    moveToInCheckAction: false,
-    moveToInCheckForm: false,
-    recommendAction: false,
-    recommendToPayForm: false,
-    recommendToRejectForm: false,
-    authoriseAction: false,
-    authoriseForm: false,
-    rejectAction: false,
-    rejectForm: false,
-    updateStatusAction: false,
-    updateStatusForm: false,
-    updateDateOfVisitAction: false,
-    updateDateOfVisitForm: false,
-    updateEligiblePiiRedactionAction: false,
-    updateEligiblePiiRedactionForm: false,
-    updateVetRCVSNumberAction: false,
-    updateVetRCVSNumberForm: false,
-    updateVetsNameAction: false,
-    updateVetsNameForm: false,
+    expect(state).toEqual({
+      withdrawAction: false,
+      moveToInCheckAction: false,
+      moveToInCheckForm: false,
+      recommendAction: false,
+      recommendToPayForm: false,
+      recommendToRejectForm: false,
+      authoriseAction: false,
+      authoriseForm: false,
+      rejectAction: false,
+      rejectForm: false,
+      updateStatusAction: false,
+      updateStatusForm: false,
+      updateDateOfVisitAction: false,
+      updateDateOfVisitForm: false,
+      updateEligiblePiiRedactionAction: false,
+      updateEligiblePiiRedactionForm: false,
+      updateVetRCVSNumberAction: false,
+      updateVetRCVSNumberForm: false,
+      updateVetsNameAction: false,
+      updateVetsNameForm: false,
+    });
   });
-});
 
-test("status: in recommended to reject, query: reject, user: recommender, recommender: different person", () => {
-  const request = {
-    query: {
-      reject: true,
-    },
-    auth: {
-      isAuthenticated: true,
-      credentials: {
-        account: { name: currentUser, username: "" },
-        scope: [recommender],
+  test("status: in recommended to reject, query: reject, user: recommender, recommender: different person", () => {
+    const request = {
+      query: {
+        reject: true,
       },
-    },
-  };
-  const currentStatusEvent = {
-    updatedBy: "someone else",
-  };
-  const state = getClaimViewStates(request, status.RECOMMENDED_TO_REJECT, currentStatusEvent);
+      auth: {
+        isAuthenticated: true,
+        credentials: {
+          account: { name: currentUser, username: "" },
+          scope: [recommender],
+        },
+      },
+    };
+    const currentStatusEvent = {
+      updatedBy: "someone else",
+    };
+    const state = getClaimViewStates({
+      request,
+      status: status.RECOMMENDED_TO_REJECT,
+      currentStatusEvent,
+    });
 
-  expect(state).toEqual({
-    withdrawAction: false,
-    moveToInCheckAction: false,
-    moveToInCheckForm: false,
-    recommendAction: false,
-    recommendToPayForm: false,
-    recommendToRejectForm: false,
-    authoriseAction: false,
-    authoriseForm: false,
-    rejectAction: false,
-    rejectForm: false,
-    updateStatusAction: false,
-    updateStatusForm: false,
-    updateDateOfVisitAction: false,
-    updateDateOfVisitForm: false,
-    updateEligiblePiiRedactionAction: false,
-    updateEligiblePiiRedactionForm: false,
-    updateVetRCVSNumberAction: false,
-    updateVetRCVSNumberForm: false,
-    updateVetsNameAction: false,
-    updateVetsNameForm: false,
+    expect(state).toEqual({
+      withdrawAction: false,
+      moveToInCheckAction: false,
+      moveToInCheckForm: false,
+      recommendAction: false,
+      recommendToPayForm: false,
+      recommendToRejectForm: false,
+      authoriseAction: false,
+      authoriseForm: false,
+      rejectAction: false,
+      rejectForm: false,
+      updateStatusAction: false,
+      updateStatusForm: false,
+      updateDateOfVisitAction: false,
+      updateDateOfVisitForm: false,
+      updateEligiblePiiRedactionAction: false,
+      updateEligiblePiiRedactionForm: false,
+      updateVetRCVSNumberAction: false,
+      updateVetRCVSNumberForm: false,
+      updateVetsNameAction: false,
+      updateVetsNameForm: false,
+    });
   });
-});
 
-test("status: in recommended to reject, query: reject, user: authoriser, recommender: different person", () => {
-  const request = {
-    query: {
-      reject: true,
-    },
-    auth: {
-      isAuthenticated: true,
-      credentials: {
-        account: { name: currentUser, username: "" },
-        scope: [authoriser],
+  test("status: in recommended to reject, query: reject, user: authoriser, recommender: different person", () => {
+    const request = {
+      query: {
+        reject: true,
       },
-    },
-  };
-  const currentStatusEvent = {
-    updatedBy: "someone else",
-  };
-  const state = getClaimViewStates(request, status.RECOMMENDED_TO_REJECT, currentStatusEvent);
+      auth: {
+        isAuthenticated: true,
+        credentials: {
+          account: { name: currentUser, username: "" },
+          scope: [authoriser],
+        },
+      },
+    };
+    const currentStatusEvent = {
+      updatedBy: "someone else",
+    };
+    const state = getClaimViewStates({
+      request,
+      status: status.RECOMMENDED_TO_REJECT,
+      currentStatusEvent,
+    });
 
-  expect(state).toEqual({
-    withdrawAction: false,
-    moveToInCheckAction: false,
-    moveToInCheckForm: false,
-    recommendAction: false,
-    recommendToPayForm: false,
-    recommendToRejectForm: false,
-    authoriseAction: false,
-    authoriseForm: false,
-    rejectAction: false,
-    rejectForm: true,
-    updateStatusAction: false,
-    updateStatusForm: false,
-    updateDateOfVisitAction: false,
-    updateDateOfVisitForm: false,
-    updateEligiblePiiRedactionAction: false,
-    updateEligiblePiiRedactionForm: false,
-    updateVetRCVSNumberAction: false,
-    updateVetRCVSNumberForm: false,
-    updateVetsNameAction: false,
-    updateVetsNameForm: false,
+    expect(state).toEqual({
+      withdrawAction: false,
+      moveToInCheckAction: false,
+      moveToInCheckForm: false,
+      recommendAction: false,
+      recommendToPayForm: false,
+      recommendToRejectForm: false,
+      authoriseAction: false,
+      authoriseForm: false,
+      rejectAction: false,
+      rejectForm: true,
+      updateStatusAction: false,
+      updateStatusForm: false,
+      updateDateOfVisitAction: false,
+      updateDateOfVisitForm: false,
+      updateEligiblePiiRedactionAction: false,
+      updateEligiblePiiRedactionForm: false,
+      updateVetRCVSNumberAction: false,
+      updateVetRCVSNumberForm: false,
+      updateVetsNameAction: false,
+      updateVetsNameForm: false,
+    });
   });
-});
 
-test("statusUpdateAction, status: any, user: admin", () => {
-  const request = {
-    query: {
-      updateStatus: false,
-    },
-    auth: {
-      isAuthenticated: true,
-      credentials: {
-        account: { name: currentUser, username: "notSuperAdmin@test" },
-        scope: [administrator],
+  test("statusUpdateAction, status: any, user: admin", () => {
+    const request = {
+      query: {
+        updateStatus: false,
       },
-    },
-  };
+      auth: {
+        isAuthenticated: true,
+        credentials: {
+          account: { name: currentUser, username: "notSuperAdmin@test" },
+          scope: [administrator],
+        },
+      },
+    };
 
-  const state = getClaimViewStates(request, status.REJECTED);
+    const state = getClaimViewStates({ request, status: status.REJECTED });
 
-  expect(state).toEqual({
-    withdrawAction: false,
-    moveToInCheckAction: false,
-    moveToInCheckForm: false,
-    recommendAction: false,
-    recommendToPayForm: false,
-    recommendToRejectForm: false,
-    authoriseAction: false,
-    authoriseForm: false,
-    rejectAction: false,
-    rejectForm: false,
-    updateStatusAction: false,
-    updateStatusForm: false,
-    updateDateOfVisitAction: false,
-    updateDateOfVisitForm: false,
-    updateEligiblePiiRedactionAction: false,
-    updateEligiblePiiRedactionForm: false,
-    updateVetRCVSNumberAction: false,
-    updateVetRCVSNumberForm: false,
-    updateVetsNameAction: false,
-    updateVetsNameForm: false,
+    expect(state).toEqual({
+      withdrawAction: false,
+      moveToInCheckAction: false,
+      moveToInCheckForm: false,
+      recommendAction: false,
+      recommendToPayForm: false,
+      recommendToRejectForm: false,
+      authoriseAction: false,
+      authoriseForm: false,
+      rejectAction: false,
+      rejectForm: false,
+      updateStatusAction: false,
+      updateStatusForm: false,
+      updateDateOfVisitAction: false,
+      updateDateOfVisitForm: false,
+      updateEligiblePiiRedactionAction: false,
+      updateEligiblePiiRedactionForm: false,
+      updateVetRCVSNumberAction: false,
+      updateVetRCVSNumberForm: false,
+      updateVetsNameAction: false,
+      updateVetsNameForm: false,
+    });
   });
-});
 
-test("statusUpdateAction, status: any, user: admin & super admin", () => {
-  const request = {
-    query: {
-      updateStatus: false,
-    },
-    auth: {
-      isAuthenticated: true,
-      credentials: {
-        account: { name: currentUser, username: "currentUser@test" },
-        scope: [administrator],
+  test("statusUpdateAction, status: any, user: admin & super admin", () => {
+    const request = {
+      query: {
+        updateStatus: false,
       },
-    },
-  };
+      auth: {
+        isAuthenticated: true,
+        credentials: {
+          account: { name: currentUser, username: "currentUser@test" },
+          scope: [administrator],
+        },
+      },
+    };
 
-  const state = getClaimViewStates(request, status.REJECTED);
+    const state = getClaimViewStates({ request, status: status.REJECTED });
 
-  expect(state).toEqual({
-    withdrawAction: false,
-    moveToInCheckAction: false,
-    moveToInCheckForm: false,
-    recommendAction: false,
-    recommendToPayForm: false,
-    recommendToRejectForm: false,
-    authoriseAction: false,
-    authoriseForm: false,
-    rejectAction: false,
-    rejectForm: false,
-    updateStatusAction: true,
-    updateStatusForm: false,
-    updateDateOfVisitAction: true,
-    updateDateOfVisitForm: false,
-    updateEligiblePiiRedactionAction: true,
-    updateEligiblePiiRedactionForm: false,
-    updateVetRCVSNumberAction: true,
-    updateVetRCVSNumberForm: false,
-    updateVetsNameAction: true,
-    updateVetsNameForm: false,
+    expect(state).toEqual({
+      withdrawAction: false,
+      moveToInCheckAction: false,
+      moveToInCheckForm: false,
+      recommendAction: false,
+      recommendToPayForm: false,
+      recommendToRejectForm: false,
+      authoriseAction: false,
+      authoriseForm: false,
+      rejectAction: false,
+      rejectForm: false,
+      updateStatusAction: true,
+      updateStatusForm: false,
+      updateDateOfVisitAction: true,
+      updateDateOfVisitForm: false,
+      updateEligiblePiiRedactionAction: true,
+      updateEligiblePiiRedactionForm: false,
+      updateVetRCVSNumberAction: true,
+      updateVetRCVSNumberForm: false,
+      updateVetsNameAction: true,
+      updateVetsNameForm: false,
+    });
   });
-});
 
-test("statusUpdateForm, status: any, query: update, user: admin", () => {
-  const request = {
-    query: {
-      update: true,
-    },
-    auth: {
-      isAuthenticated: true,
-      credentials: {
-        account: { name: currentUser, username: "notSuperAdmin@test" },
-        scope: [administrator],
+  test("statusUpdateForm, status: any, query: update, user: admin", () => {
+    const request = {
+      query: {
+        update: true,
       },
-    },
-  };
+      auth: {
+        isAuthenticated: true,
+        credentials: {
+          account: { name: currentUser, username: "notSuperAdmin@test" },
+          scope: [administrator],
+        },
+      },
+    };
 
-  const state = getClaimViewStates(request, status.REJECTED);
+    const state = getClaimViewStates({ request, status: status.REJECTED });
 
-  expect(state).toEqual({
-    withdrawAction: false,
-    moveToInCheckAction: false,
-    moveToInCheckForm: false,
-    recommendAction: false,
-    recommendToPayForm: false,
-    recommendToRejectForm: false,
-    authoriseAction: false,
-    authoriseForm: false,
-    rejectAction: false,
-    rejectForm: false,
-    updateStatusAction: false,
-    updateStatusForm: false,
-    updateDateOfVisitAction: false,
-    updateDateOfVisitForm: false,
-    updateEligiblePiiRedactionAction: false,
-    updateEligiblePiiRedactionForm: false,
-    updateVetRCVSNumberAction: false,
-    updateVetRCVSNumberForm: false,
-    updateVetsNameAction: false,
-    updateVetsNameForm: false,
+    expect(state).toEqual({
+      withdrawAction: false,
+      moveToInCheckAction: false,
+      moveToInCheckForm: false,
+      recommendAction: false,
+      recommendToPayForm: false,
+      recommendToRejectForm: false,
+      authoriseAction: false,
+      authoriseForm: false,
+      rejectAction: false,
+      rejectForm: false,
+      updateStatusAction: false,
+      updateStatusForm: false,
+      updateDateOfVisitAction: false,
+      updateDateOfVisitForm: false,
+      updateEligiblePiiRedactionAction: false,
+      updateEligiblePiiRedactionForm: false,
+      updateVetRCVSNumberAction: false,
+      updateVetRCVSNumberForm: false,
+      updateVetsNameAction: false,
+      updateVetsNameForm: false,
+    });
   });
-});
 
-test("statusUpdateForm, status: any, query: updateStatus, user: admin & super admin", () => {
-  const request = {
-    query: {
-      updateStatus: true,
-    },
-    auth: {
-      isAuthenticated: true,
-      credentials: {
-        account: { name: currentUser, username: "currentUser@test" },
-        scope: [administrator],
+  test("statusUpdateForm, status: any, query: updateStatus, user: admin & super admin", () => {
+    const request = {
+      query: {
+        updateStatus: true,
       },
-    },
-  };
+      auth: {
+        isAuthenticated: true,
+        credentials: {
+          account: { name: currentUser, username: "currentUser@test" },
+          scope: [administrator],
+        },
+      },
+    };
 
-  const state = getClaimViewStates(request, status.REJECTED);
+    const state = getClaimViewStates({ request, status: status.REJECTED });
 
-  expect(state).toEqual({
-    withdrawAction: false,
-    moveToInCheckAction: false,
-    moveToInCheckForm: false,
-    recommendAction: false,
-    recommendToPayForm: false,
-    recommendToRejectForm: false,
-    authoriseAction: false,
-    authoriseForm: false,
-    rejectAction: false,
-    rejectForm: false,
-    updateStatusAction: true,
-    updateStatusForm: true,
-    updateDateOfVisitAction: true,
-    updateDateOfVisitForm: false,
-    updateEligiblePiiRedactionAction: true,
-    updateEligiblePiiRedactionForm: false,
-    updateVetRCVSNumberAction: true,
-    updateVetRCVSNumberForm: false,
-    updateVetsNameAction: true,
-    updateVetsNameForm: false,
+    expect(state).toEqual({
+      withdrawAction: false,
+      moveToInCheckAction: false,
+      moveToInCheckForm: false,
+      recommendAction: false,
+      recommendToPayForm: false,
+      recommendToRejectForm: false,
+      authoriseAction: false,
+      authoriseForm: false,
+      rejectAction: false,
+      rejectForm: false,
+      updateStatusAction: true,
+      updateStatusForm: true,
+      updateDateOfVisitAction: true,
+      updateDateOfVisitForm: false,
+      updateEligiblePiiRedactionAction: true,
+      updateEligiblePiiRedactionForm: false,
+      updateVetRCVSNumberAction: true,
+      updateVetRCVSNumberForm: false,
+      updateVetsNameAction: true,
+      updateVetsNameForm: false,
+    });
   });
-});
 
-test("statusUpdateForm, status: ready to pay, query: updateStatus, user: admin & super admin", () => {
-  const request = {
-    query: {
-      updateStatus: true,
-    },
-    auth: {
-      isAuthenticated: true,
-      credentials: {
-        account: { name: currentUser, username: "currentUser@test" },
-        scope: [administrator],
+  test("statusUpdateForm, status: ready to pay, query: updateStatus, user: admin & super admin", () => {
+    const request = {
+      query: {
+        updateStatus: true,
       },
-    },
-  };
+      auth: {
+        isAuthenticated: true,
+        credentials: {
+          account: { name: currentUser, username: "currentUser@test" },
+          scope: [administrator],
+        },
+      },
+    };
 
-  const state = getClaimViewStates(request, status.READY_TO_PAY);
+    const state = getClaimViewStates({ request, status: status.READY_TO_PAY });
 
-  expect(state).toEqual({
-    withdrawAction: false,
-    moveToInCheckAction: false,
-    moveToInCheckForm: false,
-    recommendAction: false,
-    recommendToPayForm: false,
-    recommendToRejectForm: false,
-    authoriseAction: false,
-    authoriseForm: false,
-    rejectAction: false,
-    rejectForm: false,
-    updateStatusAction: false,
-    updateStatusForm: false,
-    updateDateOfVisitAction: true,
-    updateDateOfVisitForm: false,
-    updateEligiblePiiRedactionAction: true,
-    updateEligiblePiiRedactionForm: false,
-    updateVetRCVSNumberAction: true,
-    updateVetRCVSNumberForm: false,
-    updateVetsNameAction: true,
-    updateVetsNameForm: false,
+    expect(state).toEqual({
+      withdrawAction: false,
+      moveToInCheckAction: false,
+      moveToInCheckForm: false,
+      recommendAction: false,
+      recommendToPayForm: false,
+      recommendToRejectForm: false,
+      authoriseAction: false,
+      authoriseForm: false,
+      rejectAction: false,
+      rejectForm: false,
+      updateStatusAction: false,
+      updateStatusForm: false,
+      updateDateOfVisitAction: true,
+      updateDateOfVisitForm: false,
+      updateEligiblePiiRedactionAction: true,
+      updateEligiblePiiRedactionForm: false,
+      updateVetRCVSNumberAction: true,
+      updateVetRCVSNumberForm: false,
+      updateVetsNameAction: true,
+      updateVetsNameForm: false,
+    });
   });
 });
 
@@ -1607,7 +1669,10 @@ describe("withdraw button", () => {
   });
 
   test("withdrawAction: true when super admin, status in check and toggle enabled", () => {
-    const state = getClaimViewStates(inCheckSuperAdminRequest, status.IN_CHECK);
+    const state = getClaimViewStates({
+      request: inCheckSuperAdminRequest,
+      status: status.IN_CHECK,
+    });
 
     expect(state.withdrawAction).toBe(true);
   });
@@ -1615,13 +1680,19 @@ describe("withdraw button", () => {
   test("withdrawAction: false when toggle disabled", () => {
     config.withdrawClaimEnabled = false;
 
-    const state = getClaimViewStates(inCheckSuperAdminRequest, status.IN_CHECK);
+    const state = getClaimViewStates({
+      request: inCheckSuperAdminRequest,
+      status: status.IN_CHECK,
+    });
 
     expect(state.withdrawAction).toBe(false);
   });
 
   test("withdrawAction: false when super admin but status is not in check", () => {
-    const state = getClaimViewStates(inCheckSuperAdminRequest, status.READY_TO_PAY);
+    const state = getClaimViewStates({
+      request: inCheckSuperAdminRequest,
+      status: status.READY_TO_PAY,
+    });
 
     expect(state.withdrawAction).toBe(false);
   });
@@ -1629,13 +1700,13 @@ describe("withdraw button", () => {
   test("withdrawAction: false when the application is flagged", () => {
     const isFlagged = true;
 
-    const state = getClaimViewStates(
-      inCheckSuperAdminRequest,
-      status.IN_CHECK,
-      undefined,
-      inCheckSuperAdminRequest.query,
+    const state = getClaimViewStates({
+      request: inCheckSuperAdminRequest,
+      status: status.IN_CHECK,
+      currentStatusEvent: undefined,
+      formFlags: inCheckSuperAdminRequest.query,
       isFlagged,
-    );
+    });
 
     expect(state.withdrawAction).toBe(false);
   });
@@ -1655,7 +1726,7 @@ describe("withdraw button", () => {
       },
     };
 
-    const state = getClaimViewStates(request, status.IN_CHECK);
+    const state = getClaimViewStates({ request, status: status.IN_CHECK });
 
     expect(state.withdrawAction).toBe(false);
   });

--- a/app/routes/utils/get-claim-view-states.test.js
+++ b/app/routes/utils/get-claim-view-states.test.js
@@ -47,6 +47,12 @@ const noPermissions = {
   updateVetsNameForm: false,
 };
 
+const changeDataActions = {
+  updateDateOfVisitAction: true,
+  updateVetRCVSNumberAction: true,
+  updateVetsNameAction: true,
+};
+
 describe("getClaimViewStates", () => {
   describe("user: admin", () => {
     test("no claim status", () => {
@@ -494,11 +500,9 @@ describe("getClaimViewStates", () => {
 
       expect(state).toEqual({
         ...noPermissions,
+        ...changeDataActions,
         updateStatusAction: true,
-        updateDateOfVisitAction: true,
         updateEligiblePiiRedactionAction: true,
-        updateVetRCVSNumberAction: true,
-        updateVetsNameAction: true,
       });
     });
 
@@ -513,11 +517,9 @@ describe("getClaimViewStates", () => {
 
       expect(state).toEqual({
         ...noPermissions,
+        ...changeDataActions,
         updateStatusAction: true,
-        updateDateOfVisitAction: true,
         updateEligiblePiiRedactionAction: true,
-        updateVetRCVSNumberAction: true,
-        updateVetsNameAction: true,
       });
     });
 
@@ -532,12 +534,10 @@ describe("getClaimViewStates", () => {
 
       expect(state).toEqual({
         ...noPermissions,
+        ...changeDataActions,
         updateStatusAction: true,
         updateStatusForm: true,
-        updateDateOfVisitAction: true,
         updateEligiblePiiRedactionAction: true,
-        updateVetRCVSNumberAction: true,
-        updateVetsNameAction: true,
       });
     });
 
@@ -552,10 +552,8 @@ describe("getClaimViewStates", () => {
 
       expect(state).toEqual({
         ...noPermissions,
-        updateDateOfVisitAction: true,
+        ...changeDataActions,
         updateEligiblePiiRedactionAction: true,
-        updateVetRCVSNumberAction: true,
-        updateVetsNameAction: true,
       });
     });
   });

--- a/app/routes/utils/get-claim-view-states.test.js
+++ b/app/routes/utils/get-claim-view-states.test.js
@@ -13,6 +13,29 @@ jest.mock("../../config", () => ({
 
 const currentUser = "testUser";
 
+const noPermissions = {
+  withdrawAction: false,
+  moveToInCheckAction: false,
+  moveToInCheckForm: false,
+  recommendAction: false,
+  recommendToPayForm: false,
+  recommendToRejectForm: false,
+  authoriseAction: false,
+  authoriseForm: false,
+  rejectAction: false,
+  rejectForm: false,
+  updateStatusAction: false,
+  updateStatusForm: false,
+  updateDateOfVisitAction: false,
+  updateDateOfVisitForm: false,
+  updateEligiblePiiRedactionAction: false,
+  updateEligiblePiiRedactionForm: false,
+  updateVetRCVSNumberAction: false,
+  updateVetRCVSNumberForm: false,
+  updateVetsNameAction: false,
+  updateVetsNameForm: false,
+};
+
 describe("getClaimViewStates", () => {
   test("status: agreed, user: admin", () => {
     const request = {
@@ -29,28 +52,7 @@ describe("getClaimViewStates", () => {
     };
     const state = getClaimViewStates({ request });
 
-    expect(state).toEqual({
-      withdrawAction: false,
-      moveToInCheckAction: false,
-      moveToInCheckForm: false,
-      recommendAction: false,
-      recommendToPayForm: false,
-      recommendToRejectForm: false,
-      authoriseAction: false,
-      authoriseForm: false,
-      rejectAction: false,
-      rejectForm: false,
-      updateStatusAction: false,
-      updateStatusForm: false,
-      updateDateOfVisitAction: false,
-      updateDateOfVisitForm: false,
-      updateEligiblePiiRedactionAction: false,
-      updateEligiblePiiRedactionForm: false,
-      updateVetRCVSNumberAction: false,
-      updateVetRCVSNumberForm: false,
-      updateVetsNameAction: false,
-      updateVetsNameForm: false,
-    });
+    expect(state).toEqual(noPermissions);
   });
 
   test("status: agreed, user: recommender", () => {
@@ -68,28 +70,7 @@ describe("getClaimViewStates", () => {
     };
     const state = getClaimViewStates({ request });
 
-    expect(state).toEqual({
-      withdrawAction: false,
-      moveToInCheckAction: false,
-      moveToInCheckForm: false,
-      recommendAction: false,
-      recommendToPayForm: false,
-      recommendToRejectForm: false,
-      authoriseAction: false,
-      authoriseForm: false,
-      rejectAction: false,
-      rejectForm: false,
-      updateStatusAction: false,
-      updateStatusForm: false,
-      updateDateOfVisitAction: false,
-      updateDateOfVisitForm: false,
-      updateEligiblePiiRedactionAction: false,
-      updateEligiblePiiRedactionForm: false,
-      updateVetRCVSNumberAction: false,
-      updateVetRCVSNumberForm: false,
-      updateVetsNameAction: false,
-      updateVetsNameForm: false,
-    });
+    expect(state).toEqual(noPermissions);
   });
 
   test("status: agreed, user: authoriser", () => {
@@ -107,28 +88,7 @@ describe("getClaimViewStates", () => {
     };
     const state = getClaimViewStates({ request });
 
-    expect(state).toEqual({
-      withdrawAction: false,
-      moveToInCheckAction: false,
-      moveToInCheckForm: false,
-      recommendAction: false,
-      recommendToPayForm: false,
-      recommendToRejectForm: false,
-      authoriseAction: false,
-      authoriseForm: false,
-      rejectAction: false,
-      rejectForm: false,
-      updateStatusAction: false,
-      updateStatusForm: false,
-      updateDateOfVisitAction: false,
-      updateDateOfVisitForm: false,
-      updateEligiblePiiRedactionAction: false,
-      updateEligiblePiiRedactionForm: false,
-      updateVetRCVSNumberAction: false,
-      updateVetRCVSNumberForm: false,
-      updateVetsNameAction: false,
-      updateVetsNameForm: false,
-    });
+    expect(state).toEqual(noPermissions);
   });
 
   test("status: on hold, user: admin", () => {
@@ -147,26 +107,8 @@ describe("getClaimViewStates", () => {
     const state = getClaimViewStates({ request, claimStatus: status.ON_HOLD });
 
     expect(state).toEqual({
-      withdrawAction: false,
+      ...noPermissions,
       moveToInCheckAction: true,
-      moveToInCheckForm: false,
-      recommendAction: false,
-      recommendToPayForm: false,
-      recommendToRejectForm: false,
-      authoriseAction: false,
-      authoriseForm: false,
-      rejectAction: false,
-      rejectForm: false,
-      updateStatusAction: false,
-      updateStatusForm: false,
-      updateDateOfVisitAction: false,
-      updateDateOfVisitForm: false,
-      updateEligiblePiiRedactionAction: false,
-      updateEligiblePiiRedactionForm: false,
-      updateVetRCVSNumberAction: false,
-      updateVetRCVSNumberForm: false,
-      updateVetsNameAction: false,
-      updateVetsNameForm: false,
     });
   });
 
@@ -186,26 +128,8 @@ describe("getClaimViewStates", () => {
     const state = getClaimViewStates({ request, claimStatus: status.ON_HOLD });
 
     expect(state).toEqual({
-      withdrawAction: false,
+      ...noPermissions,
       moveToInCheckAction: true,
-      moveToInCheckForm: false,
-      recommendAction: false,
-      recommendToPayForm: false,
-      recommendToRejectForm: false,
-      authoriseAction: false,
-      authoriseForm: false,
-      rejectAction: false,
-      rejectForm: false,
-      updateStatusAction: false,
-      updateStatusForm: false,
-      updateDateOfVisitAction: false,
-      updateDateOfVisitForm: false,
-      updateEligiblePiiRedactionAction: false,
-      updateEligiblePiiRedactionForm: false,
-      updateVetRCVSNumberAction: false,
-      updateVetRCVSNumberForm: false,
-      updateVetsNameAction: false,
-      updateVetsNameForm: false,
     });
   });
 
@@ -225,26 +149,8 @@ describe("getClaimViewStates", () => {
     const state = getClaimViewStates({ request, claimStatus: status.ON_HOLD });
 
     expect(state).toEqual({
-      withdrawAction: false,
+      ...noPermissions,
       moveToInCheckAction: true,
-      moveToInCheckForm: false,
-      recommendAction: false,
-      recommendToPayForm: false,
-      recommendToRejectForm: false,
-      authoriseAction: false,
-      authoriseForm: false,
-      rejectAction: false,
-      rejectForm: false,
-      updateStatusAction: false,
-      updateStatusForm: false,
-      updateDateOfVisitAction: false,
-      updateDateOfVisitForm: false,
-      updateEligiblePiiRedactionAction: false,
-      updateEligiblePiiRedactionForm: false,
-      updateVetRCVSNumberAction: false,
-      updateVetRCVSNumberForm: false,
-      updateVetsNameAction: false,
-      updateVetsNameForm: false,
     });
   });
 
@@ -263,28 +169,7 @@ describe("getClaimViewStates", () => {
     };
     const state = getClaimViewStates({ request, claimStatus: status.ON_HOLD });
 
-    expect(state).toEqual({
-      withdrawAction: false,
-      moveToInCheckAction: false,
-      moveToInCheckForm: false,
-      recommendAction: false,
-      recommendToPayForm: false,
-      recommendToRejectForm: false,
-      authoriseAction: false,
-      authoriseForm: false,
-      rejectAction: false,
-      rejectForm: false,
-      updateStatusAction: false,
-      updateStatusForm: false,
-      updateDateOfVisitAction: false,
-      updateDateOfVisitForm: false,
-      updateEligiblePiiRedactionAction: false,
-      updateEligiblePiiRedactionForm: false,
-      updateVetRCVSNumberAction: false,
-      updateVetRCVSNumberForm: false,
-      updateVetsNameAction: false,
-      updateVetsNameForm: false,
-    });
+    expect(state).toEqual(noPermissions);
   });
 
   test("status: on hold, query: moveToInCheck, user: admin", () => {
@@ -303,26 +188,8 @@ describe("getClaimViewStates", () => {
     const state = getClaimViewStates({ request, claimStatus: status.ON_HOLD });
 
     expect(state).toEqual({
-      withdrawAction: false,
-      moveToInCheckAction: false,
+      ...noPermissions,
       moveToInCheckForm: true,
-      recommendAction: false,
-      recommendToPayForm: false,
-      recommendToRejectForm: false,
-      authoriseAction: false,
-      authoriseForm: false,
-      rejectAction: false,
-      rejectForm: false,
-      updateStatusAction: false,
-      updateStatusForm: false,
-      updateDateOfVisitAction: false,
-      updateDateOfVisitForm: false,
-      updateEligiblePiiRedactionAction: false,
-      updateEligiblePiiRedactionForm: false,
-      updateVetRCVSNumberAction: false,
-      updateVetRCVSNumberForm: false,
-      updateVetsNameAction: false,
-      updateVetsNameForm: false,
     });
   });
 
@@ -342,26 +209,8 @@ describe("getClaimViewStates", () => {
     const state = getClaimViewStates({ request, claimStatus: status.ON_HOLD });
 
     expect(state).toEqual({
-      withdrawAction: false,
-      moveToInCheckAction: false,
+      ...noPermissions,
       moveToInCheckForm: true,
-      recommendAction: false,
-      recommendToPayForm: false,
-      recommendToRejectForm: false,
-      authoriseAction: false,
-      authoriseForm: false,
-      rejectAction: false,
-      rejectForm: false,
-      updateStatusAction: false,
-      updateStatusForm: false,
-      updateDateOfVisitAction: false,
-      updateDateOfVisitForm: false,
-      updateEligiblePiiRedactionAction: false,
-      updateEligiblePiiRedactionForm: false,
-      updateVetRCVSNumberAction: false,
-      updateVetRCVSNumberForm: false,
-      updateVetsNameAction: false,
-      updateVetsNameForm: false,
     });
   });
 
@@ -381,26 +230,8 @@ describe("getClaimViewStates", () => {
     const state = getClaimViewStates({ request, claimStatus: status.ON_HOLD });
 
     expect(state).toEqual({
-      withdrawAction: false,
-      moveToInCheckAction: false,
+      ...noPermissions,
       moveToInCheckForm: true,
-      recommendAction: false,
-      recommendToPayForm: false,
-      recommendToRejectForm: false,
-      authoriseAction: false,
-      authoriseForm: false,
-      rejectAction: false,
-      rejectForm: false,
-      updateStatusAction: false,
-      updateStatusForm: false,
-      updateDateOfVisitAction: false,
-      updateDateOfVisitForm: false,
-      updateEligiblePiiRedactionAction: false,
-      updateEligiblePiiRedactionForm: false,
-      updateVetRCVSNumberAction: false,
-      updateVetRCVSNumberForm: false,
-      updateVetsNameAction: false,
-      updateVetsNameForm: false,
     });
   });
 
@@ -421,26 +252,8 @@ describe("getClaimViewStates", () => {
     const state = getClaimViewStates({ request, claimStatus: status.IN_CHECK });
 
     expect(state).toEqual({
-      withdrawAction: false,
-      moveToInCheckAction: false,
-      moveToInCheckForm: false,
+      ...noPermissions,
       recommendAction: true,
-      recommendToPayForm: false,
-      recommendToRejectForm: false,
-      authoriseAction: false,
-      authoriseForm: false,
-      rejectAction: false,
-      rejectForm: false,
-      updateStatusAction: false,
-      updateStatusForm: false,
-      updateDateOfVisitAction: false,
-      updateDateOfVisitForm: false,
-      updateEligiblePiiRedactionAction: false,
-      updateEligiblePiiRedactionForm: false,
-      updateVetRCVSNumberAction: false,
-      updateVetRCVSNumberForm: false,
-      updateVetsNameAction: false,
-      updateVetsNameForm: false,
     });
   });
 
@@ -461,26 +274,8 @@ describe("getClaimViewStates", () => {
     const state = getClaimViewStates({ request, claimStatus: status.IN_CHECK });
 
     expect(state).toEqual({
-      withdrawAction: false,
-      moveToInCheckAction: false,
-      moveToInCheckForm: false,
+      ...noPermissions,
       recommendAction: true,
-      recommendToPayForm: false,
-      recommendToRejectForm: false,
-      authoriseAction: false,
-      authoriseForm: false,
-      rejectAction: false,
-      rejectForm: false,
-      updateStatusAction: false,
-      updateStatusForm: false,
-      updateDateOfVisitAction: false,
-      updateDateOfVisitForm: false,
-      updateEligiblePiiRedactionAction: false,
-      updateEligiblePiiRedactionForm: false,
-      updateVetRCVSNumberAction: false,
-      updateVetRCVSNumberForm: false,
-      updateVetsNameAction: false,
-      updateVetsNameForm: false,
     });
   });
 
@@ -500,28 +295,7 @@ describe("getClaimViewStates", () => {
     };
     const state = getClaimViewStates({ request, claimStatus: status.IN_CHECK });
 
-    expect(state).toEqual({
-      withdrawAction: false,
-      moveToInCheckAction: false,
-      moveToInCheckForm: false,
-      recommendAction: false,
-      recommendToPayForm: false,
-      recommendToRejectForm: false,
-      authoriseAction: false,
-      authoriseForm: false,
-      rejectAction: false,
-      rejectForm: false,
-      updateStatusAction: false,
-      updateStatusForm: false,
-      updateDateOfVisitAction: false,
-      updateDateOfVisitForm: false,
-      updateEligiblePiiRedactionAction: false,
-      updateEligiblePiiRedactionForm: false,
-      updateVetRCVSNumberAction: false,
-      updateVetRCVSNumberForm: false,
-      updateVetsNameAction: false,
-      updateVetsNameForm: false,
-    });
+    expect(state).toEqual(noPermissions);
   });
 
   test("status: in check, query: recommendToPay, user: admin", () => {
@@ -540,26 +314,8 @@ describe("getClaimViewStates", () => {
     const state = getClaimViewStates({ request, claimStatus: status.IN_CHECK });
 
     expect(state).toEqual({
-      withdrawAction: false,
-      moveToInCheckAction: false,
-      moveToInCheckForm: false,
-      recommendAction: false,
+      ...noPermissions,
       recommendToPayForm: true,
-      recommendToRejectForm: false,
-      authoriseAction: false,
-      authoriseForm: false,
-      rejectAction: false,
-      rejectForm: false,
-      updateStatusAction: false,
-      updateStatusForm: false,
-      updateDateOfVisitAction: false,
-      updateDateOfVisitForm: false,
-      updateEligiblePiiRedactionAction: false,
-      updateEligiblePiiRedactionForm: false,
-      updateVetRCVSNumberAction: false,
-      updateVetRCVSNumberForm: false,
-      updateVetsNameAction: false,
-      updateVetsNameForm: false,
     });
   });
 
@@ -578,28 +334,7 @@ describe("getClaimViewStates", () => {
     };
     const state = getClaimViewStates({ request, claimStatus: status.IN_CHECK });
 
-    expect(state).toEqual({
-      withdrawAction: false,
-      moveToInCheckAction: false,
-      moveToInCheckForm: false,
-      recommendAction: false,
-      recommendToPayForm: true,
-      recommendToRejectForm: false,
-      authoriseAction: false,
-      authoriseForm: false,
-      rejectAction: false,
-      rejectForm: false,
-      updateStatusAction: false,
-      updateStatusForm: false,
-      updateDateOfVisitAction: false,
-      updateDateOfVisitForm: false,
-      updateEligiblePiiRedactionAction: false,
-      updateEligiblePiiRedactionForm: false,
-      updateVetRCVSNumberAction: false,
-      updateVetRCVSNumberForm: false,
-      updateVetsNameAction: false,
-      updateVetsNameForm: false,
-    });
+    expect(state).toEqual({ ...noPermissions, recommendToPayForm: true });
   });
 
   test("status: in check, query: recommendToPay, user: authoriser", () => {
@@ -617,28 +352,7 @@ describe("getClaimViewStates", () => {
     };
     const state = getClaimViewStates({ request, claimStatus: status.IN_CHECK });
 
-    expect(state).toEqual({
-      withdrawAction: false,
-      moveToInCheckAction: false,
-      moveToInCheckForm: false,
-      recommendAction: false,
-      recommendToPayForm: false,
-      recommendToRejectForm: false,
-      authoriseAction: false,
-      authoriseForm: false,
-      rejectAction: false,
-      rejectForm: false,
-      updateStatusAction: false,
-      updateStatusForm: false,
-      updateDateOfVisitAction: false,
-      updateDateOfVisitForm: false,
-      updateEligiblePiiRedactionAction: false,
-      updateEligiblePiiRedactionForm: false,
-      updateVetRCVSNumberAction: false,
-      updateVetRCVSNumberForm: false,
-      updateVetsNameAction: false,
-      updateVetsNameForm: false,
-    });
+    expect(state).toEqual(noPermissions);
   });
 
   test("status: in check, query: recommendToReject, user: admin", () => {
@@ -656,28 +370,7 @@ describe("getClaimViewStates", () => {
     };
     const state = getClaimViewStates({ request, claimStatus: status.IN_CHECK });
 
-    expect(state).toEqual({
-      withdrawAction: false,
-      moveToInCheckAction: false,
-      moveToInCheckForm: false,
-      recommendAction: false,
-      recommendToPayForm: false,
-      recommendToRejectForm: true,
-      authoriseAction: false,
-      authoriseForm: false,
-      rejectAction: false,
-      rejectForm: false,
-      updateStatusAction: false,
-      updateStatusForm: false,
-      updateDateOfVisitAction: false,
-      updateDateOfVisitForm: false,
-      updateEligiblePiiRedactionAction: false,
-      updateEligiblePiiRedactionForm: false,
-      updateVetRCVSNumberAction: false,
-      updateVetRCVSNumberForm: false,
-      updateVetsNameAction: false,
-      updateVetsNameForm: false,
-    });
+    expect(state).toEqual({ ...noPermissions, recommendToRejectForm: true });
   });
 
   test("status: in check, query: recommendToReject, user: recommender", () => {
@@ -696,26 +389,8 @@ describe("getClaimViewStates", () => {
     const state = getClaimViewStates({ request, claimStatus: status.IN_CHECK });
 
     expect(state).toEqual({
-      withdrawAction: false,
-      moveToInCheckAction: false,
-      moveToInCheckForm: false,
-      recommendAction: false,
-      recommendToPayForm: false,
+      ...noPermissions,
       recommendToRejectForm: true,
-      authoriseAction: false,
-      authoriseForm: false,
-      rejectAction: false,
-      rejectForm: false,
-      updateStatusAction: false,
-      updateStatusForm: false,
-      updateDateOfVisitAction: false,
-      updateDateOfVisitForm: false,
-      updateEligiblePiiRedactionAction: false,
-      updateEligiblePiiRedactionForm: false,
-      updateVetRCVSNumberAction: false,
-      updateVetRCVSNumberForm: false,
-      updateVetsNameAction: false,
-      updateVetsNameForm: false,
     });
   });
 
@@ -734,28 +409,7 @@ describe("getClaimViewStates", () => {
     };
     const state = getClaimViewStates({ request, claimStatus: status.IN_CHECK });
 
-    expect(state).toEqual({
-      withdrawAction: false,
-      moveToInCheckAction: false,
-      moveToInCheckForm: false,
-      recommendAction: false,
-      recommendToPayForm: false,
-      recommendToRejectForm: false,
-      authoriseAction: false,
-      authoriseForm: false,
-      rejectAction: false,
-      rejectForm: false,
-      updateStatusAction: false,
-      updateStatusForm: false,
-      updateDateOfVisitAction: false,
-      updateDateOfVisitForm: false,
-      updateEligiblePiiRedactionAction: false,
-      updateEligiblePiiRedactionForm: false,
-      updateVetRCVSNumberAction: false,
-      updateVetRCVSNumberForm: false,
-      updateVetsNameAction: false,
-      updateVetsNameForm: false,
-    });
+    expect(state).toEqual(noPermissions);
   });
 
   test("status: in recommended to pay, user: admin, recommender: different person", () => {
@@ -780,28 +434,7 @@ describe("getClaimViewStates", () => {
       currentStatusEvent,
     });
 
-    expect(state).toEqual({
-      withdrawAction: false,
-      moveToInCheckAction: false,
-      moveToInCheckForm: false,
-      recommendAction: false,
-      recommendToPayForm: false,
-      recommendToRejectForm: false,
-      authoriseAction: true,
-      authoriseForm: false,
-      rejectAction: false,
-      rejectForm: false,
-      updateStatusAction: false,
-      updateStatusForm: false,
-      updateDateOfVisitAction: false,
-      updateDateOfVisitForm: false,
-      updateEligiblePiiRedactionAction: false,
-      updateEligiblePiiRedactionForm: false,
-      updateVetRCVSNumberAction: false,
-      updateVetRCVSNumberForm: false,
-      updateVetsNameAction: false,
-      updateVetsNameForm: false,
-    });
+    expect(state).toEqual({ ...noPermissions, authoriseAction: true });
   });
 
   test("status: in recommended to pay, user: admin, recommender: same person", () => {
@@ -826,28 +459,7 @@ describe("getClaimViewStates", () => {
       currentStatusEvent,
     });
 
-    expect(state).toEqual({
-      withdrawAction: false,
-      moveToInCheckAction: false,
-      moveToInCheckForm: false,
-      recommendAction: false,
-      recommendToPayForm: false,
-      recommendToRejectForm: false,
-      authoriseAction: false,
-      authoriseForm: false,
-      rejectAction: false,
-      rejectForm: false,
-      updateStatusAction: false,
-      updateStatusForm: false,
-      updateDateOfVisitAction: false,
-      updateDateOfVisitForm: false,
-      updateEligiblePiiRedactionAction: false,
-      updateEligiblePiiRedactionForm: false,
-      updateVetRCVSNumberAction: false,
-      updateVetRCVSNumberForm: false,
-      updateVetsNameAction: false,
-      updateVetsNameForm: false,
-    });
+    expect(state).toEqual(noPermissions);
   });
 
   test("status: in recommended to pay, user: recommender, recommender: different person", () => {
@@ -872,28 +484,7 @@ describe("getClaimViewStates", () => {
       currentStatusEvent,
     });
 
-    expect(state).toEqual({
-      withdrawAction: false,
-      moveToInCheckAction: false,
-      moveToInCheckForm: false,
-      recommendAction: false,
-      recommendToPayForm: false,
-      recommendToRejectForm: false,
-      authoriseAction: false,
-      authoriseForm: false,
-      rejectAction: false,
-      rejectForm: false,
-      updateStatusAction: false,
-      updateStatusForm: false,
-      updateDateOfVisitAction: false,
-      updateDateOfVisitForm: false,
-      updateEligiblePiiRedactionAction: false,
-      updateEligiblePiiRedactionForm: false,
-      updateVetRCVSNumberAction: false,
-      updateVetRCVSNumberForm: false,
-      updateVetsNameAction: false,
-      updateVetsNameForm: false,
-    });
+    expect(state).toEqual(noPermissions);
   });
 
   test("status: in recommended to pay, user: authoriser, recommender: different person", () => {
@@ -919,26 +510,8 @@ describe("getClaimViewStates", () => {
     });
 
     expect(state).toEqual({
-      withdrawAction: false,
-      moveToInCheckAction: false,
-      moveToInCheckForm: false,
-      recommendAction: false,
-      recommendToPayForm: false,
-      recommendToRejectForm: false,
+      ...noPermissions,
       authoriseAction: true,
-      authoriseForm: false,
-      rejectAction: false,
-      rejectForm: false,
-      updateStatusAction: false,
-      updateStatusForm: false,
-      updateDateOfVisitAction: false,
-      updateDateOfVisitForm: false,
-      updateEligiblePiiRedactionAction: false,
-      updateEligiblePiiRedactionForm: false,
-      updateVetRCVSNumberAction: false,
-      updateVetRCVSNumberForm: false,
-      updateVetsNameAction: false,
-      updateVetsNameForm: false,
     });
   });
 
@@ -965,26 +538,8 @@ describe("getClaimViewStates", () => {
     });
 
     expect(state).toEqual({
-      withdrawAction: false,
-      moveToInCheckAction: false,
-      moveToInCheckForm: false,
-      recommendAction: false,
-      recommendToPayForm: false,
-      recommendToRejectForm: false,
-      authoriseAction: false,
+      ...noPermissions,
       authoriseForm: true,
-      rejectAction: false,
-      rejectForm: false,
-      updateStatusAction: false,
-      updateStatusForm: false,
-      updateDateOfVisitAction: false,
-      updateDateOfVisitForm: false,
-      updateEligiblePiiRedactionAction: false,
-      updateEligiblePiiRedactionForm: false,
-      updateVetRCVSNumberAction: false,
-      updateVetRCVSNumberForm: false,
-      updateVetsNameAction: false,
-      updateVetsNameForm: false,
     });
   });
 
@@ -1010,28 +565,7 @@ describe("getClaimViewStates", () => {
       currentStatusEvent,
     });
 
-    expect(state).toEqual({
-      withdrawAction: false,
-      moveToInCheckAction: false,
-      moveToInCheckForm: false,
-      recommendAction: false,
-      recommendToPayForm: false,
-      recommendToRejectForm: false,
-      authoriseAction: false,
-      authoriseForm: false,
-      rejectAction: false,
-      rejectForm: false,
-      updateStatusAction: false,
-      updateStatusForm: false,
-      updateDateOfVisitAction: false,
-      updateDateOfVisitForm: false,
-      updateEligiblePiiRedactionAction: false,
-      updateEligiblePiiRedactionForm: false,
-      updateVetRCVSNumberAction: false,
-      updateVetRCVSNumberForm: false,
-      updateVetsNameAction: false,
-      updateVetsNameForm: false,
-    });
+    expect(state).toEqual(noPermissions);
   });
 
   test("status: in recommended to pay, query: approve, user: authoriser, recommender: different person", () => {
@@ -1057,26 +591,8 @@ describe("getClaimViewStates", () => {
     });
 
     expect(state).toEqual({
-      withdrawAction: false,
-      moveToInCheckAction: false,
-      moveToInCheckForm: false,
-      recommendAction: false,
-      recommendToPayForm: false,
-      recommendToRejectForm: false,
-      authoriseAction: false,
+      ...noPermissions,
       authoriseForm: true,
-      rejectAction: false,
-      rejectForm: false,
-      updateStatusAction: false,
-      updateStatusForm: false,
-      updateDateOfVisitAction: false,
-      updateDateOfVisitForm: false,
-      updateEligiblePiiRedactionAction: false,
-      updateEligiblePiiRedactionForm: false,
-      updateVetRCVSNumberAction: false,
-      updateVetRCVSNumberForm: false,
-      updateVetsNameAction: false,
-      updateVetsNameForm: false,
     });
   });
 
@@ -1194,28 +710,7 @@ describe("getClaimViewStates", () => {
       currentStatusEvent,
     });
 
-    expect(state).toEqual({
-      withdrawAction: false,
-      moveToInCheckAction: false,
-      moveToInCheckForm: false,
-      recommendAction: false,
-      recommendToPayForm: false,
-      recommendToRejectForm: false,
-      authoriseAction: false,
-      authoriseForm: false,
-      rejectAction: false,
-      rejectForm: false,
-      updateStatusAction: false,
-      updateStatusForm: false,
-      updateDateOfVisitAction: false,
-      updateDateOfVisitForm: false,
-      updateEligiblePiiRedactionAction: false,
-      updateEligiblePiiRedactionForm: false,
-      updateVetRCVSNumberAction: false,
-      updateVetRCVSNumberForm: false,
-      updateVetsNameAction: false,
-      updateVetsNameForm: false,
-    });
+    expect(state).toEqual(noPermissions);
   });
 
   test("status: in recommended to reject, user: authoriser, recommender: different person", () => {
@@ -1241,26 +736,8 @@ describe("getClaimViewStates", () => {
     });
 
     expect(state).toEqual({
-      withdrawAction: false,
-      moveToInCheckAction: false,
-      moveToInCheckForm: false,
-      recommendAction: false,
-      recommendToPayForm: false,
-      recommendToRejectForm: false,
-      authoriseAction: false,
-      authoriseForm: false,
+      ...noPermissions,
       rejectAction: true,
-      rejectForm: false,
-      updateStatusAction: false,
-      updateStatusForm: false,
-      updateDateOfVisitAction: false,
-      updateDateOfVisitForm: false,
-      updateEligiblePiiRedactionAction: false,
-      updateEligiblePiiRedactionForm: false,
-      updateVetRCVSNumberAction: false,
-      updateVetRCVSNumberForm: false,
-      updateVetsNameAction: false,
-      updateVetsNameForm: false,
     });
   });
 
@@ -1287,26 +764,8 @@ describe("getClaimViewStates", () => {
     });
 
     expect(state).toEqual({
-      withdrawAction: false,
-      moveToInCheckAction: false,
-      moveToInCheckForm: false,
-      recommendAction: false,
-      recommendToPayForm: false,
-      recommendToRejectForm: false,
-      authoriseAction: false,
-      authoriseForm: false,
-      rejectAction: false,
+      ...noPermissions,
       rejectForm: true,
-      updateStatusAction: false,
-      updateStatusForm: false,
-      updateDateOfVisitAction: false,
-      updateDateOfVisitForm: false,
-      updateEligiblePiiRedactionAction: false,
-      updateEligiblePiiRedactionForm: false,
-      updateVetRCVSNumberAction: false,
-      updateVetRCVSNumberForm: false,
-      updateVetsNameAction: false,
-      updateVetsNameForm: false,
     });
   });
 
@@ -1332,28 +791,7 @@ describe("getClaimViewStates", () => {
       currentStatusEvent,
     });
 
-    expect(state).toEqual({
-      withdrawAction: false,
-      moveToInCheckAction: false,
-      moveToInCheckForm: false,
-      recommendAction: false,
-      recommendToPayForm: false,
-      recommendToRejectForm: false,
-      authoriseAction: false,
-      authoriseForm: false,
-      rejectAction: false,
-      rejectForm: false,
-      updateStatusAction: false,
-      updateStatusForm: false,
-      updateDateOfVisitAction: false,
-      updateDateOfVisitForm: false,
-      updateEligiblePiiRedactionAction: false,
-      updateEligiblePiiRedactionForm: false,
-      updateVetRCVSNumberAction: false,
-      updateVetRCVSNumberForm: false,
-      updateVetsNameAction: false,
-      updateVetsNameForm: false,
-    });
+    expect(state).toEqual(noPermissions);
   });
 
   test("status: in recommended to reject, query: reject, user: recommender, recommender: different person", () => {
@@ -1378,28 +816,7 @@ describe("getClaimViewStates", () => {
       currentStatusEvent,
     });
 
-    expect(state).toEqual({
-      withdrawAction: false,
-      moveToInCheckAction: false,
-      moveToInCheckForm: false,
-      recommendAction: false,
-      recommendToPayForm: false,
-      recommendToRejectForm: false,
-      authoriseAction: false,
-      authoriseForm: false,
-      rejectAction: false,
-      rejectForm: false,
-      updateStatusAction: false,
-      updateStatusForm: false,
-      updateDateOfVisitAction: false,
-      updateDateOfVisitForm: false,
-      updateEligiblePiiRedactionAction: false,
-      updateEligiblePiiRedactionForm: false,
-      updateVetRCVSNumberAction: false,
-      updateVetRCVSNumberForm: false,
-      updateVetsNameAction: false,
-      updateVetsNameForm: false,
-    });
+    expect(state).toEqual(noPermissions);
   });
 
   test("status: in recommended to reject, query: reject, user: authoriser, recommender: different person", () => {
@@ -1425,26 +842,8 @@ describe("getClaimViewStates", () => {
     });
 
     expect(state).toEqual({
-      withdrawAction: false,
-      moveToInCheckAction: false,
-      moveToInCheckForm: false,
-      recommendAction: false,
-      recommendToPayForm: false,
-      recommendToRejectForm: false,
-      authoriseAction: false,
-      authoriseForm: false,
-      rejectAction: false,
+      ...noPermissions,
       rejectForm: true,
-      updateStatusAction: false,
-      updateStatusForm: false,
-      updateDateOfVisitAction: false,
-      updateDateOfVisitForm: false,
-      updateEligiblePiiRedactionAction: false,
-      updateEligiblePiiRedactionForm: false,
-      updateVetRCVSNumberAction: false,
-      updateVetRCVSNumberForm: false,
-      updateVetsNameAction: false,
-      updateVetsNameForm: false,
     });
   });
 
@@ -1464,28 +863,7 @@ describe("getClaimViewStates", () => {
 
     const state = getClaimViewStates({ request, claimStatus: status.REJECTED });
 
-    expect(state).toEqual({
-      withdrawAction: false,
-      moveToInCheckAction: false,
-      moveToInCheckForm: false,
-      recommendAction: false,
-      recommendToPayForm: false,
-      recommendToRejectForm: false,
-      authoriseAction: false,
-      authoriseForm: false,
-      rejectAction: false,
-      rejectForm: false,
-      updateStatusAction: false,
-      updateStatusForm: false,
-      updateDateOfVisitAction: false,
-      updateDateOfVisitForm: false,
-      updateEligiblePiiRedactionAction: false,
-      updateEligiblePiiRedactionForm: false,
-      updateVetRCVSNumberAction: false,
-      updateVetRCVSNumberForm: false,
-      updateVetsNameAction: false,
-      updateVetsNameForm: false,
-    });
+    expect(state).toEqual(noPermissions);
   });
 
   test("statusUpdateAction, claimStatus: any, user: admin & super admin", () => {
@@ -1505,26 +883,12 @@ describe("getClaimViewStates", () => {
     const state = getClaimViewStates({ request, claimStatus: status.REJECTED });
 
     expect(state).toEqual({
-      withdrawAction: false,
-      moveToInCheckAction: false,
-      moveToInCheckForm: false,
-      recommendAction: false,
-      recommendToPayForm: false,
-      recommendToRejectForm: false,
-      authoriseAction: false,
-      authoriseForm: false,
-      rejectAction: false,
-      rejectForm: false,
+      ...noPermissions,
       updateStatusAction: true,
-      updateStatusForm: false,
       updateDateOfVisitAction: true,
-      updateDateOfVisitForm: false,
       updateEligiblePiiRedactionAction: true,
-      updateEligiblePiiRedactionForm: false,
       updateVetRCVSNumberAction: true,
-      updateVetRCVSNumberForm: false,
       updateVetsNameAction: true,
-      updateVetsNameForm: false,
     });
   });
 
@@ -1544,28 +908,7 @@ describe("getClaimViewStates", () => {
 
     const state = getClaimViewStates({ request, claimStatus: status.REJECTED });
 
-    expect(state).toEqual({
-      withdrawAction: false,
-      moveToInCheckAction: false,
-      moveToInCheckForm: false,
-      recommendAction: false,
-      recommendToPayForm: false,
-      recommendToRejectForm: false,
-      authoriseAction: false,
-      authoriseForm: false,
-      rejectAction: false,
-      rejectForm: false,
-      updateStatusAction: false,
-      updateStatusForm: false,
-      updateDateOfVisitAction: false,
-      updateDateOfVisitForm: false,
-      updateEligiblePiiRedactionAction: false,
-      updateEligiblePiiRedactionForm: false,
-      updateVetRCVSNumberAction: false,
-      updateVetRCVSNumberForm: false,
-      updateVetsNameAction: false,
-      updateVetsNameForm: false,
-    });
+    expect(state).toEqual(noPermissions);
   });
 
   test("statusUpdateForm, claimStatus: any, query: updateStatus, user: admin & super admin", () => {
@@ -1585,26 +928,13 @@ describe("getClaimViewStates", () => {
     const state = getClaimViewStates({ request, claimStatus: status.REJECTED });
 
     expect(state).toEqual({
-      withdrawAction: false,
-      moveToInCheckAction: false,
-      moveToInCheckForm: false,
-      recommendAction: false,
-      recommendToPayForm: false,
-      recommendToRejectForm: false,
-      authoriseAction: false,
-      authoriseForm: false,
-      rejectAction: false,
-      rejectForm: false,
+      ...noPermissions,
       updateStatusAction: true,
       updateStatusForm: true,
       updateDateOfVisitAction: true,
-      updateDateOfVisitForm: false,
       updateEligiblePiiRedactionAction: true,
-      updateEligiblePiiRedactionForm: false,
       updateVetRCVSNumberAction: true,
-      updateVetRCVSNumberForm: false,
       updateVetsNameAction: true,
-      updateVetsNameForm: false,
     });
   });
 
@@ -1625,26 +955,11 @@ describe("getClaimViewStates", () => {
     const state = getClaimViewStates({ request, claimStatus: status.READY_TO_PAY });
 
     expect(state).toEqual({
-      withdrawAction: false,
-      moveToInCheckAction: false,
-      moveToInCheckForm: false,
-      recommendAction: false,
-      recommendToPayForm: false,
-      recommendToRejectForm: false,
-      authoriseAction: false,
-      authoriseForm: false,
-      rejectAction: false,
-      rejectForm: false,
-      updateStatusAction: false,
-      updateStatusForm: false,
+      ...noPermissions,
       updateDateOfVisitAction: true,
-      updateDateOfVisitForm: false,
       updateEligiblePiiRedactionAction: true,
-      updateEligiblePiiRedactionForm: false,
       updateVetRCVSNumberAction: true,
-      updateVetRCVSNumberForm: false,
       updateVetsNameAction: true,
-      updateVetsNameForm: false,
     });
   });
 });

--- a/app/routes/utils/get-claim-view-states.test.js
+++ b/app/routes/utils/get-claim-view-states.test.js
@@ -13,6 +13,17 @@ jest.mock("../../config", () => ({
 
 const currentUser = "testUser";
 
+const buildRequest = ({ scope, query = {}, username = "" }) => ({
+  query,
+  auth: {
+    isAuthenticated: true,
+    credentials: {
+      account: { name: currentUser, username },
+      scope: [scope],
+    },
+  },
+});
+
 const noPermissions = {
   withdrawAction: false,
   moveToInCheckAction: false,
@@ -37,947 +48,507 @@ const noPermissions = {
 };
 
 describe("getClaimViewStates", () => {
-  test("status: agreed, user: admin", () => {
-    const request = {
-      query: {
-        withdraw: false,
-      },
-      auth: {
-        isAuthenticated: true,
-        credentials: {
-          account: { name: currentUser, username: "" },
-          scope: [administrator],
-        },
-      },
-    };
-    const state = getClaimViewStates({ request });
+  describe("user: admin", () => {
+    test("status: agreed", () => {
+      const request = buildRequest({ scope: administrator, query: { withdraw: false } });
+      const state = getClaimViewStates({ request });
 
-    expect(state).toEqual(noPermissions);
-  });
+      expect(state).toEqual(noPermissions);
+    });
 
-  test("status: agreed, user: recommender", () => {
-    const request = {
-      query: {
-        withdraw: false,
-      },
-      auth: {
-        isAuthenticated: true,
-        credentials: {
-          account: { name: currentUser, username: "" },
-          scope: [recommender],
-        },
-      },
-    };
-    const state = getClaimViewStates({ request });
+    test("status: on hold", () => {
+      const request = buildRequest({ scope: administrator, query: { moveToInCheck: false } });
+      const state = getClaimViewStates({ request, claimStatus: status.ON_HOLD });
 
-    expect(state).toEqual(noPermissions);
-  });
+      expect(state).toEqual({
+        ...noPermissions,
+        moveToInCheckAction: true,
+      });
+    });
 
-  test("status: agreed, user: authoriser", () => {
-    const request = {
-      query: {
-        withdraw: false,
-      },
-      auth: {
-        isAuthenticated: true,
-        credentials: {
-          account: { name: currentUser, username: "" },
-          scope: [authoriser],
-        },
-      },
-    };
-    const state = getClaimViewStates({ request });
+    test("status: on hold, query: moveToInCheck", () => {
+      const request = buildRequest({ scope: administrator, query: { moveToInCheck: true } });
+      const state = getClaimViewStates({ request, claimStatus: status.ON_HOLD });
 
-    expect(state).toEqual(noPermissions);
-  });
+      expect(state).toEqual({
+        ...noPermissions,
+        moveToInCheckForm: true,
+      });
+    });
 
-  test("status: on hold, user: admin", () => {
-    const request = {
-      query: {
-        moveToInCheck: false,
-      },
-      auth: {
-        isAuthenticated: true,
-        credentials: {
-          account: { name: currentUser, username: "" },
-          scope: [administrator],
-        },
-      },
-    };
-    const state = getClaimViewStates({ request, claimStatus: status.ON_HOLD });
+    test("status: in check", () => {
+      const request = buildRequest({
+        scope: administrator,
+        query: { recommendToPay: false, recommendToReject: false },
+      });
+      const state = getClaimViewStates({ request, claimStatus: status.IN_CHECK });
 
-    expect(state).toEqual({
-      ...noPermissions,
-      moveToInCheckAction: true,
+      expect(state).toEqual({
+        ...noPermissions,
+        recommendAction: true,
+      });
+    });
+
+    test("status: in check, query: recommendToPay", () => {
+      const request = buildRequest({ scope: administrator, query: { recommendToPay: true } });
+      const state = getClaimViewStates({ request, claimStatus: status.IN_CHECK });
+
+      expect(state).toEqual({
+        ...noPermissions,
+        recommendToPayForm: true,
+      });
+    });
+
+    test("status: in check, query: recommendToReject", () => {
+      const request = buildRequest({ scope: administrator, query: { recommendToReject: true } });
+      const state = getClaimViewStates({ request, claimStatus: status.IN_CHECK });
+
+      expect(state).toEqual({ ...noPermissions, recommendToRejectForm: true });
+    });
+
+    test("status: in recommended to pay, recommender: different person", () => {
+      const request = buildRequest({ scope: administrator, query: { approve: false } });
+      const currentStatusEvent = {
+        updatedBy: "someone else",
+      };
+      const state = getClaimViewStates({
+        request,
+        claimStatus: status.RECOMMENDED_TO_PAY,
+        currentStatusEvent,
+      });
+
+      expect(state).toEqual({ ...noPermissions, authoriseAction: true });
+    });
+
+    test("status: in recommended to pay, recommender: same person", () => {
+      const request = buildRequest({ scope: administrator, query: { approve: false } });
+      const currentStatusEvent = {
+        updatedBy: currentUser,
+      };
+      const state = getClaimViewStates({
+        request,
+        claimStatus: status.RECOMMENDED_TO_PAY,
+        currentStatusEvent,
+      });
+
+      expect(state).toEqual(noPermissions);
+    });
+
+    test("status: in recommended to pay, query: approve, recommender: different person", () => {
+      const request = buildRequest({ scope: administrator, query: { approve: true } });
+      const currentStatusEvent = {
+        updatedBy: "someone else",
+      };
+      const state = getClaimViewStates({
+        request,
+        claimStatus: status.RECOMMENDED_TO_PAY,
+        currentStatusEvent,
+      });
+
+      expect(state).toEqual({
+        ...noPermissions,
+        authoriseForm: true,
+      });
+    });
+
+    test("status: in recommended to reject, recommender: different person", () => {
+      const request = buildRequest({ scope: administrator, query: { reject: false } });
+      const currentStatusEvent = {
+        updatedBy: "someone else",
+      };
+      const state = getClaimViewStates({
+        request,
+        claimStatus: status.RECOMMENDED_TO_REJECT,
+        currentStatusEvent,
+      });
+
+      expect(state).toEqual({
+        ...noPermissions,
+        rejectAction: true,
+      });
+    });
+
+    test("status: in recommended to reject, recommender: same person", () => {
+      const request = buildRequest({ scope: administrator, query: { reject: false } });
+      const currentStatusEvent = {
+        updatedBy: currentUser,
+      };
+      const state = getClaimViewStates({
+        request,
+        claimStatus: status.RECOMMENDED_TO_REJECT,
+        currentStatusEvent,
+      });
+
+      expect(state).toEqual(noPermissions);
+    });
+
+    test("status: in recommended to reject, query: reject, recommender: different person", () => {
+      const request = buildRequest({ scope: administrator, query: { reject: true } });
+      const currentStatusEvent = {
+        updatedBy: "someone else",
+      };
+      const state = getClaimViewStates({
+        request,
+        claimStatus: status.RECOMMENDED_TO_REJECT,
+        currentStatusEvent,
+      });
+
+      expect(state).toEqual({
+        ...noPermissions,
+        rejectForm: true,
+      });
+    });
+
+    test("status: in recommended to reject, query: reject, recommender: same person", () => {
+      const request = buildRequest({ scope: administrator, query: { reject: true } });
+      const currentStatusEvent = {
+        updatedBy: currentUser,
+      };
+      const state = getClaimViewStates({
+        request,
+        claimStatus: status.RECOMMENDED_TO_REJECT,
+        currentStatusEvent,
+      });
+
+      expect(state).toEqual(noPermissions);
+    });
+
+    test("statusUpdateAction, claimStatus: any", () => {
+      const request = buildRequest({
+        scope: administrator,
+        query: { updateStatus: false },
+        username: "notSuperAdmin@test",
+      });
+
+      const state = getClaimViewStates({ request, claimStatus: status.REJECTED });
+
+      expect(state).toEqual(noPermissions);
+    });
+
+    test("statusUpdateForm, claimStatus: any, query: update", () => {
+      const request = buildRequest({
+        scope: administrator,
+        query: { update: true },
+        username: "notSuperAdmin@test",
+      });
+
+      const state = getClaimViewStates({ request, claimStatus: status.REJECTED });
+
+      expect(state).toEqual(noPermissions);
     });
   });
 
-  test("status: on hold, user: recommender", () => {
-    const request = {
-      query: {
-        moveToInCheck: false,
-      },
-      auth: {
-        isAuthenticated: true,
-        credentials: {
-          account: { name: currentUser, username: "" },
-          scope: [recommender],
-        },
-      },
-    };
-    const state = getClaimViewStates({ request, claimStatus: status.ON_HOLD });
+  describe("user: recommender", () => {
+    test("status: agreed", () => {
+      const request = buildRequest({ scope: recommender, query: { withdraw: false } });
+      const state = getClaimViewStates({ request });
 
-    expect(state).toEqual({
-      ...noPermissions,
-      moveToInCheckAction: true,
+      expect(state).toEqual(noPermissions);
+    });
+
+    test("status: on hold", () => {
+      const request = buildRequest({ scope: recommender, query: { moveToInCheck: false } });
+      const state = getClaimViewStates({ request, claimStatus: status.ON_HOLD });
+
+      expect(state).toEqual({
+        ...noPermissions,
+        moveToInCheckAction: true,
+      });
+    });
+
+    test("status: on hold, query: moveToInCheck", () => {
+      const request = buildRequest({ scope: recommender, query: { moveToInCheck: true } });
+      const state = getClaimViewStates({ request, claimStatus: status.ON_HOLD });
+
+      expect(state).toEqual({
+        ...noPermissions,
+        moveToInCheckForm: true,
+      });
+    });
+
+    test("status: in check", () => {
+      const request = buildRequest({
+        scope: recommender,
+        query: { recommendToPay: false, recommendToReject: false },
+      });
+      const state = getClaimViewStates({ request, claimStatus: status.IN_CHECK });
+
+      expect(state).toEqual({
+        ...noPermissions,
+        recommendAction: true,
+      });
+    });
+
+    test("status: in check, query: recommendToPay", () => {
+      const request = buildRequest({ scope: recommender, query: { recommendToPay: true } });
+      const state = getClaimViewStates({ request, claimStatus: status.IN_CHECK });
+
+      expect(state).toEqual({ ...noPermissions, recommendToPayForm: true });
+    });
+
+    test("status: in check, query: recommendToReject", () => {
+      const request = buildRequest({ scope: recommender, query: { recommendToReject: true } });
+      const state = getClaimViewStates({ request, claimStatus: status.IN_CHECK });
+
+      expect(state).toEqual({
+        ...noPermissions,
+        recommendToRejectForm: true,
+      });
+    });
+
+    test("status: in recommended to pay, recommender: different person", () => {
+      const request = buildRequest({ scope: recommender, query: { approve: false } });
+      const currentStatusEvent = {
+        updatedBy: "someone else",
+      };
+      const state = getClaimViewStates({
+        request,
+        claimStatus: status.RECOMMENDED_TO_PAY,
+        currentStatusEvent,
+      });
+
+      expect(state).toEqual(noPermissions);
+    });
+
+    test("status: in recommended to pay, query: approve, recommender: different person", () => {
+      const request = buildRequest({ scope: recommender, query: { approve: true } });
+      const currentStatusEvent = {
+        updatedBy: "someone else",
+      };
+      const state = getClaimViewStates({
+        request,
+        claimStatus: status.RECOMMENDED_TO_PAY,
+        currentStatusEvent,
+      });
+
+      expect(state).toEqual(noPermissions);
+    });
+
+    test("status: in recommended to reject, recommender: different person", () => {
+      const request = buildRequest({ scope: recommender, query: { reject: false } });
+      const currentStatusEvent = {
+        updatedBy: "someone else",
+      };
+      const state = getClaimViewStates({
+        request,
+        claimStatus: status.RECOMMENDED_TO_REJECT,
+        currentStatusEvent,
+      });
+
+      expect(state).toEqual(noPermissions);
+    });
+
+    test("status: in recommended to reject, query: reject, recommender: different person", () => {
+      const request = buildRequest({ scope: recommender, query: { reject: true } });
+      const currentStatusEvent = {
+        updatedBy: "someone else",
+      };
+      const state = getClaimViewStates({
+        request,
+        claimStatus: status.RECOMMENDED_TO_REJECT,
+        currentStatusEvent,
+      });
+
+      expect(state).toEqual(noPermissions);
     });
   });
 
-  test("status: on hold, user: authoriser", () => {
-    const request = {
-      query: {
-        moveToInCheck: false,
-      },
-      auth: {
-        isAuthenticated: true,
-        credentials: {
-          account: { name: currentUser, username: "" },
-          scope: [authoriser],
-        },
-      },
-    };
-    const state = getClaimViewStates({ request, claimStatus: status.ON_HOLD });
+  describe("user: authoriser", () => {
+    test("status: agreed", () => {
+      const request = buildRequest({ scope: authoriser, query: { withdraw: false } });
+      const state = getClaimViewStates({ request });
 
-    expect(state).toEqual({
-      ...noPermissions,
-      moveToInCheckAction: true,
+      expect(state).toEqual(noPermissions);
+    });
+
+    test("status: on hold", () => {
+      const request = buildRequest({ scope: authoriser, query: { moveToInCheck: false } });
+      const state = getClaimViewStates({ request, claimStatus: status.ON_HOLD });
+
+      expect(state).toEqual({
+        ...noPermissions,
+        moveToInCheckAction: true,
+      });
+    });
+
+    test("status: on hold, query: moveToInCheck", () => {
+      const request = buildRequest({ scope: authoriser, query: { moveToInCheck: true } });
+      const state = getClaimViewStates({ request, claimStatus: status.ON_HOLD });
+
+      expect(state).toEqual({
+        ...noPermissions,
+        moveToInCheckForm: true,
+      });
+    });
+
+    test("status: in check", () => {
+      const request = buildRequest({
+        scope: authoriser,
+        query: { recommendToPay: false, recommendToReject: false },
+      });
+      const state = getClaimViewStates({ request, claimStatus: status.IN_CHECK });
+
+      expect(state).toEqual(noPermissions);
+    });
+
+    test("status: in check, query: recommendToPay", () => {
+      const request = buildRequest({ scope: authoriser, query: { recommendToPay: true } });
+      const state = getClaimViewStates({ request, claimStatus: status.IN_CHECK });
+
+      expect(state).toEqual(noPermissions);
+    });
+
+    test("status: in check, query: recommendToReject", () => {
+      const request = buildRequest({ scope: authoriser, query: { recommendToReject: true } });
+      const state = getClaimViewStates({ request, claimStatus: status.IN_CHECK });
+
+      expect(state).toEqual(noPermissions);
+    });
+
+    test("status: in recommended to pay, recommender: different person", () => {
+      const request = buildRequest({ scope: authoriser, query: { approve: false } });
+      const currentStatusEvent = {
+        updatedBy: "someone else",
+      };
+      const state = getClaimViewStates({
+        request,
+        claimStatus: status.RECOMMENDED_TO_PAY,
+        currentStatusEvent,
+      });
+
+      expect(state).toEqual({
+        ...noPermissions,
+        authoriseAction: true,
+      });
+    });
+
+    test("status: in recommended to pay, query: approve, recommender: different person", () => {
+      const request = buildRequest({ scope: authoriser, query: { approve: true } });
+      const currentStatusEvent = {
+        updatedBy: "someone else",
+      };
+      const state = getClaimViewStates({
+        request,
+        claimStatus: status.RECOMMENDED_TO_PAY,
+        currentStatusEvent,
+      });
+
+      expect(state).toEqual({
+        ...noPermissions,
+        authoriseForm: true,
+      });
+    });
+
+    test("status: in recommended to reject, recommender: different person", () => {
+      const request = buildRequest({ scope: authoriser, query: { reject: false } });
+      const currentStatusEvent = {
+        updatedBy: "someone else",
+      };
+      const state = getClaimViewStates({
+        request,
+        claimStatus: status.RECOMMENDED_TO_REJECT,
+        currentStatusEvent,
+      });
+
+      expect(state).toEqual({
+        ...noPermissions,
+        rejectAction: true,
+      });
+    });
+
+    test("status: in recommended to reject, query: reject, recommender: different person", () => {
+      const request = buildRequest({ scope: authoriser, query: { reject: true } });
+      const currentStatusEvent = {
+        updatedBy: "someone else",
+      };
+      const state = getClaimViewStates({
+        request,
+        claimStatus: status.RECOMMENDED_TO_REJECT,
+        currentStatusEvent,
+      });
+
+      expect(state).toEqual({
+        ...noPermissions,
+        rejectForm: true,
+      });
     });
   });
 
-  test("status: on hold, user: user", () => {
-    const request = {
-      query: {
-        moveToInCheck: false,
-      },
-      auth: {
-        isAuthenticated: true,
-        credentials: {
-          account: { name: currentUser, username: "" },
-          scope: [user],
-        },
-      },
-    };
-    const state = getClaimViewStates({ request, claimStatus: status.ON_HOLD });
+  describe("user: user", () => {
+    test("status: on hold", () => {
+      const request = buildRequest({ scope: user, query: { moveToInCheck: false } });
+      const state = getClaimViewStates({ request, claimStatus: status.ON_HOLD });
 
-    expect(state).toEqual(noPermissions);
-  });
-
-  test("status: on hold, query: moveToInCheck, user: admin", () => {
-    const request = {
-      query: {
-        moveToInCheck: true,
-      },
-      auth: {
-        isAuthenticated: true,
-        credentials: {
-          account: { name: currentUser, username: "" },
-          scope: [administrator],
-        },
-      },
-    };
-    const state = getClaimViewStates({ request, claimStatus: status.ON_HOLD });
-
-    expect(state).toEqual({
-      ...noPermissions,
-      moveToInCheckForm: true,
+      expect(state).toEqual(noPermissions);
     });
   });
 
-  test("status: on hold, query: moveToInCheck, user: recommender", () => {
-    const request = {
-      query: {
-        moveToInCheck: true,
-      },
-      auth: {
-        isAuthenticated: true,
-        credentials: {
-          account: { name: currentUser, username: "" },
-          scope: [recommender],
-        },
-      },
-    };
-    const state = getClaimViewStates({ request, claimStatus: status.ON_HOLD });
+  describe("user: super admin", () => {
+    test("statusUpdateAction, claimStatus: any", () => {
+      const request = buildRequest({
+        scope: administrator,
+        query: { updateStatus: false },
+        username: "currentUser@test",
+      });
 
-    expect(state).toEqual({
-      ...noPermissions,
-      moveToInCheckForm: true,
-    });
-  });
+      const state = getClaimViewStates({ request, claimStatus: status.REJECTED });
 
-  test("status: on hold, query: moveToInCheck, user: authoriser", () => {
-    const request = {
-      query: {
-        moveToInCheck: true,
-      },
-      auth: {
-        isAuthenticated: true,
-        credentials: {
-          account: { name: currentUser, username: "" },
-          scope: [authoriser],
-        },
-      },
-    };
-    const state = getClaimViewStates({ request, claimStatus: status.ON_HOLD });
-
-    expect(state).toEqual({
-      ...noPermissions,
-      moveToInCheckForm: true,
-    });
-  });
-
-  test("status: in check, user: admin", () => {
-    const request = {
-      query: {
-        recommendToPay: false,
-        recommendToReject: false,
-      },
-      auth: {
-        isAuthenticated: true,
-        credentials: {
-          account: { name: currentUser, username: "" },
-          scope: [administrator],
-        },
-      },
-    };
-    const state = getClaimViewStates({ request, claimStatus: status.IN_CHECK });
-
-    expect(state).toEqual({
-      ...noPermissions,
-      recommendAction: true,
-    });
-  });
-
-  test("status: in check, user: recommender", () => {
-    const request = {
-      query: {
-        recommendToPay: false,
-        recommendToReject: false,
-      },
-      auth: {
-        isAuthenticated: true,
-        credentials: {
-          account: { name: currentUser, username: "" },
-          scope: [recommender],
-        },
-      },
-    };
-    const state = getClaimViewStates({ request, claimStatus: status.IN_CHECK });
-
-    expect(state).toEqual({
-      ...noPermissions,
-      recommendAction: true,
-    });
-  });
-
-  test("status: in check, user: authoriser", () => {
-    const request = {
-      query: {
-        recommendToPay: false,
-        recommendToReject: false,
-      },
-      auth: {
-        isAuthenticated: true,
-        credentials: {
-          account: { name: currentUser, username: "" },
-          scope: [authoriser],
-        },
-      },
-    };
-    const state = getClaimViewStates({ request, claimStatus: status.IN_CHECK });
-
-    expect(state).toEqual(noPermissions);
-  });
-
-  test("status: in check, query: recommendToPay, user: admin", () => {
-    const request = {
-      query: {
-        recommendToPay: true,
-      },
-      auth: {
-        isAuthenticated: true,
-        credentials: {
-          account: { name: currentUser, username: "" },
-          scope: [administrator],
-        },
-      },
-    };
-    const state = getClaimViewStates({ request, claimStatus: status.IN_CHECK });
-
-    expect(state).toEqual({
-      ...noPermissions,
-      recommendToPayForm: true,
-    });
-  });
-
-  test("status: in check, query: recommendToPay, user: recommender", () => {
-    const request = {
-      query: {
-        recommendToPay: true,
-      },
-      auth: {
-        isAuthenticated: true,
-        credentials: {
-          account: { name: currentUser, username: "" },
-          scope: [recommender],
-        },
-      },
-    };
-    const state = getClaimViewStates({ request, claimStatus: status.IN_CHECK });
-
-    expect(state).toEqual({ ...noPermissions, recommendToPayForm: true });
-  });
-
-  test("status: in check, query: recommendToPay, user: authoriser", () => {
-    const request = {
-      query: {
-        recommendToPay: true,
-      },
-      auth: {
-        isAuthenticated: true,
-        credentials: {
-          account: { name: currentUser, username: "" },
-          scope: [authoriser],
-        },
-      },
-    };
-    const state = getClaimViewStates({ request, claimStatus: status.IN_CHECK });
-
-    expect(state).toEqual(noPermissions);
-  });
-
-  test("status: in check, query: recommendToReject, user: admin", () => {
-    const request = {
-      query: {
-        recommendToReject: true,
-      },
-      auth: {
-        isAuthenticated: true,
-        credentials: {
-          account: { name: currentUser, username: "" },
-          scope: [administrator],
-        },
-      },
-    };
-    const state = getClaimViewStates({ request, claimStatus: status.IN_CHECK });
-
-    expect(state).toEqual({ ...noPermissions, recommendToRejectForm: true });
-  });
-
-  test("status: in check, query: recommendToReject, user: recommender", () => {
-    const request = {
-      query: {
-        recommendToReject: true,
-      },
-      auth: {
-        isAuthenticated: true,
-        credentials: {
-          account: { name: currentUser, username: "" },
-          scope: [recommender],
-        },
-      },
-    };
-    const state = getClaimViewStates({ request, claimStatus: status.IN_CHECK });
-
-    expect(state).toEqual({
-      ...noPermissions,
-      recommendToRejectForm: true,
-    });
-  });
-
-  test("status: in check, query: recommendToReject, user: authoriser", () => {
-    const request = {
-      query: {
-        recommendToReject: true,
-      },
-      auth: {
-        isAuthenticated: true,
-        credentials: {
-          account: { name: currentUser, username: "" },
-          scope: [authoriser],
-        },
-      },
-    };
-    const state = getClaimViewStates({ request, claimStatus: status.IN_CHECK });
-
-    expect(state).toEqual(noPermissions);
-  });
-
-  test("status: in recommended to pay, user: admin, recommender: different person", () => {
-    const request = {
-      query: {
-        approve: false,
-      },
-      auth: {
-        isAuthenticated: true,
-        credentials: {
-          account: { name: currentUser, username: "" },
-          scope: [administrator],
-        },
-      },
-    };
-    const currentStatusEvent = {
-      updatedBy: "someone else",
-    };
-    const state = getClaimViewStates({
-      request,
-      claimStatus: status.RECOMMENDED_TO_PAY,
-      currentStatusEvent,
+      expect(state).toEqual({
+        ...noPermissions,
+        updateStatusAction: true,
+        updateDateOfVisitAction: true,
+        updateEligiblePiiRedactionAction: true,
+        updateVetRCVSNumberAction: true,
+        updateVetsNameAction: true,
+      });
     });
 
-    expect(state).toEqual({ ...noPermissions, authoriseAction: true });
-  });
+    test("statusUpdateForm, claimStatus: any, query: updateStatus", () => {
+      const request = buildRequest({
+        scope: administrator,
+        query: { updateStatus: true },
+        username: "currentUser@test",
+      });
 
-  test("status: in recommended to pay, user: admin, recommender: same person", () => {
-    const request = {
-      query: {
-        approve: false,
-      },
-      auth: {
-        isAuthenticated: true,
-        credentials: {
-          account: { name: currentUser, username: "" },
-          scope: [administrator],
-        },
-      },
-    };
-    const currentStatusEvent = {
-      updatedBy: currentUser,
-    };
-    const state = getClaimViewStates({
-      request,
-      claimStatus: status.RECOMMENDED_TO_PAY,
-      currentStatusEvent,
+      const state = getClaimViewStates({ request, claimStatus: status.REJECTED });
+
+      expect(state).toEqual({
+        ...noPermissions,
+        updateStatusAction: true,
+        updateStatusForm: true,
+        updateDateOfVisitAction: true,
+        updateEligiblePiiRedactionAction: true,
+        updateVetRCVSNumberAction: true,
+        updateVetsNameAction: true,
+      });
     });
 
-    expect(state).toEqual(noPermissions);
-  });
+    test("statusUpdateForm, claimStatus: ready to pay, query: updateStatus", () => {
+      const request = buildRequest({
+        scope: administrator,
+        query: { updateStatus: true },
+        username: "currentUser@test",
+      });
 
-  test("status: in recommended to pay, user: recommender, recommender: different person", () => {
-    const request = {
-      query: {
-        approve: false,
-      },
-      auth: {
-        isAuthenticated: true,
-        credentials: {
-          account: { name: currentUser, username: "" },
-          scope: [recommender],
-        },
-      },
-    };
-    const currentStatusEvent = {
-      updatedBy: "someone else",
-    };
-    const state = getClaimViewStates({
-      request,
-      claimStatus: status.RECOMMENDED_TO_PAY,
-      currentStatusEvent,
-    });
+      const state = getClaimViewStates({ request, claimStatus: status.READY_TO_PAY });
 
-    expect(state).toEqual(noPermissions);
-  });
-
-  test("status: in recommended to pay, user: authoriser, recommender: different person", () => {
-    const request = {
-      query: {
-        approve: false,
-      },
-      auth: {
-        isAuthenticated: true,
-        credentials: {
-          account: { name: currentUser, username: "" },
-          scope: [authoriser],
-        },
-      },
-    };
-    const currentStatusEvent = {
-      updatedBy: "someone else",
-    };
-    const state = getClaimViewStates({
-      request,
-      claimStatus: status.RECOMMENDED_TO_PAY,
-      currentStatusEvent,
-    });
-
-    expect(state).toEqual({
-      ...noPermissions,
-      authoriseAction: true,
-    });
-  });
-
-  test("status: in recommended to pay, query: approve, user: admin, recommender: different person", () => {
-    const request = {
-      query: {
-        approve: true,
-      },
-      auth: {
-        isAuthenticated: true,
-        credentials: {
-          account: { name: currentUser, username: "" },
-          scope: [administrator],
-        },
-      },
-    };
-    const currentStatusEvent = {
-      updatedBy: "someone else",
-    };
-    const state = getClaimViewStates({
-      request,
-      claimStatus: status.RECOMMENDED_TO_PAY,
-      currentStatusEvent,
-    });
-
-    expect(state).toEqual({
-      ...noPermissions,
-      authoriseForm: true,
-    });
-  });
-
-  test("status: in recommended to pay, query: approve, user: recommender, recommender: different person", () => {
-    const request = {
-      query: {
-        approve: true,
-      },
-      auth: {
-        isAuthenticated: true,
-        credentials: {
-          account: { name: currentUser, username: "" },
-          scope: [recommender],
-        },
-      },
-    };
-    const currentStatusEvent = {
-      updatedBy: "someone else",
-    };
-    const state = getClaimViewStates({
-      request,
-      claimStatus: status.RECOMMENDED_TO_PAY,
-      currentStatusEvent,
-    });
-
-    expect(state).toEqual(noPermissions);
-  });
-
-  test("status: in recommended to pay, query: approve, user: authoriser, recommender: different person", () => {
-    const request = {
-      query: {
-        approve: true,
-      },
-      auth: {
-        isAuthenticated: true,
-        credentials: {
-          account: { name: currentUser, username: "" },
-          scope: [authoriser],
-        },
-      },
-    };
-    const currentStatusEvent = {
-      updatedBy: "someone else",
-    };
-    const state = getClaimViewStates({
-      request,
-      claimStatus: status.RECOMMENDED_TO_PAY,
-      currentStatusEvent,
-    });
-
-    expect(state).toEqual({
-      ...noPermissions,
-      authoriseForm: true,
-    });
-  });
-
-  test("status: in recommended to reject, user: admin, recommender: different person", () => {
-    const request = {
-      query: {
-        reject: false,
-      },
-      auth: {
-        isAuthenticated: true,
-        credentials: {
-          account: { name: currentUser, username: "" },
-          scope: [administrator],
-        },
-      },
-    };
-    const currentStatusEvent = {
-      updatedBy: "someone else",
-    };
-    const state = getClaimViewStates({
-      request,
-      claimStatus: status.RECOMMENDED_TO_REJECT,
-      currentStatusEvent,
-    });
-
-    expect(state).toEqual({
-      withdrawAction: false,
-      moveToInCheckAction: false,
-      moveToInCheckForm: false,
-      recommendAction: false,
-      recommendToPayForm: false,
-      recommendToRejectForm: false,
-      authoriseAction: false,
-      authoriseForm: false,
-      rejectAction: true,
-      rejectForm: false,
-      updateStatusAction: false,
-      updateStatusForm: false,
-      updateDateOfVisitAction: false,
-      updateDateOfVisitForm: false,
-      updateEligiblePiiRedactionAction: false,
-      updateEligiblePiiRedactionForm: false,
-      updateVetRCVSNumberAction: false,
-      updateVetRCVSNumberForm: false,
-      updateVetsNameAction: false,
-      updateVetsNameForm: false,
-    });
-  });
-
-  test("status: in recommended to reject, user: admin, recommender: same person", () => {
-    const request = {
-      query: {
-        reject: false,
-      },
-      auth: {
-        isAuthenticated: true,
-        credentials: {
-          account: { name: currentUser, username: "" },
-          scope: [administrator],
-        },
-      },
-    };
-    const currentStatusEvent = {
-      updatedBy: currentUser,
-    };
-    const state = getClaimViewStates({
-      request,
-      claimStatus: status.RECOMMENDED_TO_REJECT,
-      currentStatusEvent,
-    });
-
-    expect(state).toEqual({
-      withdrawAction: false,
-      moveToInCheckAction: false,
-      moveToInCheckForm: false,
-      recommendAction: false,
-      recommendToPayForm: false,
-      recommendToRejectForm: false,
-      authoriseAction: false,
-      authoriseForm: false,
-      rejectAction: false,
-      rejectForm: false,
-      updateStatusAction: false,
-      updateStatusForm: false,
-      updateDateOfVisitAction: false,
-      updateDateOfVisitForm: false,
-      updateEligiblePiiRedactionAction: false,
-      updateEligiblePiiRedactionForm: false,
-      updateVetRCVSNumberAction: false,
-      updateVetRCVSNumberForm: false,
-      updateVetsNameAction: false,
-      updateVetsNameForm: false,
-    });
-  });
-
-  test("status: in recommended to reject, user: recommender, recommender: different person", () => {
-    const request = {
-      query: {
-        reject: false,
-      },
-      auth: {
-        isAuthenticated: true,
-        credentials: {
-          account: { name: currentUser, username: "" },
-          scope: [recommender],
-        },
-      },
-    };
-    const currentStatusEvent = {
-      updatedBy: "someone else",
-    };
-    const state = getClaimViewStates({
-      request,
-      claimStatus: status.RECOMMENDED_TO_REJECT,
-      currentStatusEvent,
-    });
-
-    expect(state).toEqual(noPermissions);
-  });
-
-  test("status: in recommended to reject, user: authoriser, recommender: different person", () => {
-    const request = {
-      query: {
-        reject: false,
-      },
-      auth: {
-        isAuthenticated: true,
-        credentials: {
-          account: { name: currentUser, username: "" },
-          scope: [authoriser],
-        },
-      },
-    };
-    const currentStatusEvent = {
-      updatedBy: "someone else",
-    };
-    const state = getClaimViewStates({
-      request,
-      claimStatus: status.RECOMMENDED_TO_REJECT,
-      currentStatusEvent,
-    });
-
-    expect(state).toEqual({
-      ...noPermissions,
-      rejectAction: true,
-    });
-  });
-
-  test("status: in recommended to reject, query: reject, user: admin, recommender: different person", () => {
-    const request = {
-      query: {
-        reject: true,
-      },
-      auth: {
-        isAuthenticated: true,
-        credentials: {
-          account: { name: currentUser, username: "" },
-          scope: [administrator],
-        },
-      },
-    };
-    const currentStatusEvent = {
-      updatedBy: "someone else",
-    };
-    const state = getClaimViewStates({
-      request,
-      claimStatus: status.RECOMMENDED_TO_REJECT,
-      currentStatusEvent,
-    });
-
-    expect(state).toEqual({
-      ...noPermissions,
-      rejectForm: true,
-    });
-  });
-
-  test("status: in recommended to reject, query: reject, user: admin, recommender: same person", () => {
-    const request = {
-      query: {
-        reject: true,
-      },
-      auth: {
-        isAuthenticated: true,
-        credentials: {
-          account: { name: currentUser, username: "" },
-          scope: [administrator],
-        },
-      },
-    };
-    const currentStatusEvent = {
-      updatedBy: currentUser,
-    };
-    const state = getClaimViewStates({
-      request,
-      claimStatus: status.RECOMMENDED_TO_REJECT,
-      currentStatusEvent,
-    });
-
-    expect(state).toEqual(noPermissions);
-  });
-
-  test("status: in recommended to reject, query: reject, user: recommender, recommender: different person", () => {
-    const request = {
-      query: {
-        reject: true,
-      },
-      auth: {
-        isAuthenticated: true,
-        credentials: {
-          account: { name: currentUser, username: "" },
-          scope: [recommender],
-        },
-      },
-    };
-    const currentStatusEvent = {
-      updatedBy: "someone else",
-    };
-    const state = getClaimViewStates({
-      request,
-      claimStatus: status.RECOMMENDED_TO_REJECT,
-      currentStatusEvent,
-    });
-
-    expect(state).toEqual(noPermissions);
-  });
-
-  test("status: in recommended to reject, query: reject, user: authoriser, recommender: different person", () => {
-    const request = {
-      query: {
-        reject: true,
-      },
-      auth: {
-        isAuthenticated: true,
-        credentials: {
-          account: { name: currentUser, username: "" },
-          scope: [authoriser],
-        },
-      },
-    };
-    const currentStatusEvent = {
-      updatedBy: "someone else",
-    };
-    const state = getClaimViewStates({
-      request,
-      claimStatus: status.RECOMMENDED_TO_REJECT,
-      currentStatusEvent,
-    });
-
-    expect(state).toEqual({
-      ...noPermissions,
-      rejectForm: true,
-    });
-  });
-
-  test("statusUpdateAction, claimStatus: any, user: admin", () => {
-    const request = {
-      query: {
-        updateStatus: false,
-      },
-      auth: {
-        isAuthenticated: true,
-        credentials: {
-          account: { name: currentUser, username: "notSuperAdmin@test" },
-          scope: [administrator],
-        },
-      },
-    };
-
-    const state = getClaimViewStates({ request, claimStatus: status.REJECTED });
-
-    expect(state).toEqual(noPermissions);
-  });
-
-  test("statusUpdateAction, claimStatus: any, user: admin & super admin", () => {
-    const request = {
-      query: {
-        updateStatus: false,
-      },
-      auth: {
-        isAuthenticated: true,
-        credentials: {
-          account: { name: currentUser, username: "currentUser@test" },
-          scope: [administrator],
-        },
-      },
-    };
-
-    const state = getClaimViewStates({ request, claimStatus: status.REJECTED });
-
-    expect(state).toEqual({
-      ...noPermissions,
-      updateStatusAction: true,
-      updateDateOfVisitAction: true,
-      updateEligiblePiiRedactionAction: true,
-      updateVetRCVSNumberAction: true,
-      updateVetsNameAction: true,
-    });
-  });
-
-  test("statusUpdateForm, claimStatus: any, query: update, user: admin", () => {
-    const request = {
-      query: {
-        update: true,
-      },
-      auth: {
-        isAuthenticated: true,
-        credentials: {
-          account: { name: currentUser, username: "notSuperAdmin@test" },
-          scope: [administrator],
-        },
-      },
-    };
-
-    const state = getClaimViewStates({ request, claimStatus: status.REJECTED });
-
-    expect(state).toEqual(noPermissions);
-  });
-
-  test("statusUpdateForm, claimStatus: any, query: updateStatus, user: admin & super admin", () => {
-    const request = {
-      query: {
-        updateStatus: true,
-      },
-      auth: {
-        isAuthenticated: true,
-        credentials: {
-          account: { name: currentUser, username: "currentUser@test" },
-          scope: [administrator],
-        },
-      },
-    };
-
-    const state = getClaimViewStates({ request, claimStatus: status.REJECTED });
-
-    expect(state).toEqual({
-      ...noPermissions,
-      updateStatusAction: true,
-      updateStatusForm: true,
-      updateDateOfVisitAction: true,
-      updateEligiblePiiRedactionAction: true,
-      updateVetRCVSNumberAction: true,
-      updateVetsNameAction: true,
-    });
-  });
-
-  test("statusUpdateForm, claimStatus: ready to pay, query: updateStatus, user: admin & super admin", () => {
-    const request = {
-      query: {
-        updateStatus: true,
-      },
-      auth: {
-        isAuthenticated: true,
-        credentials: {
-          account: { name: currentUser, username: "currentUser@test" },
-          scope: [administrator],
-        },
-      },
-    };
-
-    const state = getClaimViewStates({ request, claimStatus: status.READY_TO_PAY });
-
-    expect(state).toEqual({
-      ...noPermissions,
-      updateDateOfVisitAction: true,
-      updateEligiblePiiRedactionAction: true,
-      updateVetRCVSNumberAction: true,
-      updateVetsNameAction: true,
+      expect(state).toEqual({
+        ...noPermissions,
+        updateDateOfVisitAction: true,
+        updateEligiblePiiRedactionAction: true,
+        updateVetRCVSNumberAction: true,
+        updateVetsNameAction: true,
+      });
     });
   });
 });
 
 describe("withdraw button", () => {
-  const inCheckSuperAdminRequest = {
-    query: {
-      recommendToPay: false,
-      recommendToReject: false,
-    },
-    auth: {
-      isAuthenticated: true,
-      credentials: {
-        account: { name: currentUser, username: "currentUser@test" },
-        scope: [administrator],
-      },
-    },
-  };
+  const inCheckSuperAdminRequest = buildRequest({
+    scope: administrator,
+    query: { recommendToPay: false, recommendToReject: false },
+    username: "currentUser@test",
+  });
 
   afterEach(() => {
     config.withdrawClaimEnabled = true;
@@ -1027,19 +598,11 @@ describe("withdraw button", () => {
   });
 
   test("withdrawAction: false when status in check but user is not a super admin", () => {
-    const request = {
-      query: {
-        recommendToPay: false,
-        recommendToReject: false,
-      },
-      auth: {
-        isAuthenticated: true,
-        credentials: {
-          account: { name: currentUser, username: "notSuperAdmin@test" },
-          scope: [administrator],
-        },
-      },
-    };
+    const request = buildRequest({
+      scope: administrator,
+      query: { recommendToPay: false, recommendToReject: false },
+      username: "notSuperAdmin@test",
+    });
 
     const state = getClaimViewStates({ request, claimStatus: status.IN_CHECK });
 

--- a/app/routes/utils/get-claim-view-states.test.js
+++ b/app/routes/utils/get-claim-view-states.test.js
@@ -1,10 +1,10 @@
-import { getClaimViewStates } from "../../../../app/routes/utils/get-claim-view-states.js";
+import { getClaimViewStates } from "./get-claim-view-states.js";
 import { STATUS as status } from "ffc-ahwr-common-library";
-import { permissions } from "../../../../app/auth/permissions.js";
-import { config } from "../../../../app/config/index.js";
+import { permissions } from "../../auth/permissions.js";
+import { config } from "../../config/index.js";
 const { administrator, recommender, authoriser, user } = permissions;
 
-jest.mock("../../../../app/config", () => ({
+jest.mock("../../config", () => ({
   config: {
     superAdmins: ["currentuser@test"],
     withdrawClaimEnabled: true,

--- a/app/routes/utils/get-claim-view-states.test.js
+++ b/app/routes/utils/get-claim-view-states.test.js
@@ -49,8 +49,8 @@ const noPermissions = {
 
 describe("getClaimViewStates", () => {
   describe("user: admin", () => {
-    test("status: agreed", () => {
-      const request = buildRequest({ scope: administrator, query: { withdraw: false } });
+    test("no claim status", () => {
+      const request = buildRequest({ scope: administrator });
       const state = getClaimViewStates({ request });
 
       expect(state).toEqual(noPermissions);
@@ -239,8 +239,8 @@ describe("getClaimViewStates", () => {
   });
 
   describe("user: recommender", () => {
-    test("status: agreed", () => {
-      const request = buildRequest({ scope: recommender, query: { withdraw: false } });
+    test("no claim status", () => {
+      const request = buildRequest({ scope: recommender });
       const state = getClaimViewStates({ request });
 
       expect(state).toEqual(noPermissions);
@@ -354,8 +354,8 @@ describe("getClaimViewStates", () => {
   });
 
   describe("user: authoriser", () => {
-    test("status: agreed", () => {
-      const request = buildRequest({ scope: authoriser, query: { withdraw: false } });
+    test("no claim status", () => {
+      const request = buildRequest({ scope: authoriser });
       const state = getClaimViewStates({ request });
 
       expect(state).toEqual(noPermissions);
@@ -484,6 +484,24 @@ describe("getClaimViewStates", () => {
   });
 
   describe("user: super admin", () => {
+    test("no claim status", () => {
+      const request = buildRequest({
+        scope: administrator,
+        username: "currentUser@test",
+      });
+
+      const state = getClaimViewStates({ request });
+
+      expect(state).toEqual({
+        ...noPermissions,
+        updateStatusAction: true,
+        updateDateOfVisitAction: true,
+        updateEligiblePiiRedactionAction: true,
+        updateVetRCVSNumberAction: true,
+        updateVetsNameAction: true,
+      });
+    });
+
     test("statusUpdateAction, claimStatus: any", () => {
       const request = buildRequest({
         scope: administrator,

--- a/app/routes/view-agreement.js
+++ b/app/routes/view-agreement.js
@@ -65,7 +65,7 @@ export const buildViewAgreement = async (
 
   const viewStates = application.redacted
     ? {}
-    : getClaimViewStates(request, status, currentStatusEvent, formFlags);
+    : getClaimViewStates({ request, status, currentStatusEvent, formFlags });
   const { updateVetsNameForm, updateVetRCVSNumberForm, updateDateOfVisitForm } = viewStates;
   const { updateEligiblePiiRedactionAction, updateEligiblePiiRedactionForm } = viewStates;
 

--- a/app/routes/view-agreement.js
+++ b/app/routes/view-agreement.js
@@ -3,6 +3,7 @@ import { getApplication, getOldWorldApplicationHistory } from "../api/applicatio
 import { permissions } from "../auth/permissions.js";
 import { getStyleClassByStatus } from "../constants/status.js";
 import { getClaimViewStates } from "./utils/get-claim-view-states.js";
+import { getApplicationStates } from "./utils/get-application-states.js";
 import { getCurrentStatusEvent } from "./utils/get-current-status-event.js";
 import { getErrorMessagesByKey } from "./utils/get-error-messages-by-key.js";
 import { getContactHistory, displayContactHistory } from "../api/contact-history.js";
@@ -65,7 +66,10 @@ export const buildViewAgreement = async (
 
   const viewStates = application.redacted
     ? {}
-    : getClaimViewStates({ request, currentStatusEvent, formFlags });
+    : {
+        ...getClaimViewStates({ request, currentStatusEvent, formFlags }),
+        ...getApplicationStates({ request, formFlags }),
+      };
   const { updateVetsNameForm, updateVetRCVSNumberForm, updateDateOfVisitForm } = viewStates;
   const { updateEligiblePiiRedactionAction, updateEligiblePiiRedactionForm } = viewStates;
 

--- a/app/routes/view-agreement.js
+++ b/app/routes/view-agreement.js
@@ -65,7 +65,7 @@ export const buildViewAgreement = async (
 
   const viewStates = application.redacted
     ? {}
-    : getClaimViewStates({ request, status, currentStatusEvent, formFlags });
+    : getClaimViewStates({ request, currentStatusEvent, formFlags });
   const { updateVetsNameForm, updateVetRCVSNumberForm, updateDateOfVisitForm } = viewStates;
   const { updateEligiblePiiRedactionAction, updateEligiblePiiRedactionForm } = viewStates;
 

--- a/app/routes/view-claim.js
+++ b/app/routes/view-claim.js
@@ -104,7 +104,7 @@ export const buildViewClaim = async (
     ? {}
     : getClaimViewStates({
         request,
-        status: claim.status,
+        claimStatus: claim.status,
         currentStatusEvent,
         formFlags,
         isFlagged,

--- a/app/routes/view-claim.js
+++ b/app/routes/view-claim.js
@@ -102,7 +102,13 @@ export const buildViewClaim = async (
 
   const viewStates = application.redacted
     ? {}
-    : getClaimViewStates(request, claim.status, currentStatusEvent, formFlags, isFlagged);
+    : getClaimViewStates({
+        request,
+        status: claim.status,
+        currentStatusEvent,
+        formFlags,
+        isFlagged,
+      });
 
   const scheme = getScheme(applicationReference);
 

--- a/app/routes/withdrawal-claim.js
+++ b/app/routes/withdrawal-claim.js
@@ -8,6 +8,7 @@ import { canWithdrawClaim } from "./utils/can-withdraw-claim.js";
 import { mapAuth } from "../auth/map-auth.js";
 import { getClaim, withdrawClaim } from "../api/claims.js";
 import { getApplication } from "../api/applications.js";
+import { WITHDRAWAL_REASONS, WITHDRAWAL_ISSUE_DISCOVERIES } from "../constants/withdrawal.js";
 
 const { administrator } = permissions;
 
@@ -57,6 +58,8 @@ const renderWithdrawalPage = (h, { reference, page, returnPage, values = {}, err
     backLink: viewClaimLink(reference, page, returnPage),
     errors,
     errorMessages: getErrorMessagesByKey(errors),
+    reasonForWithdrawalItems: WITHDRAWAL_REASONS,
+    issueDiscoveryItems: WITHDRAWAL_ISSUE_DISCOVERIES,
     ...values,
   });
 

--- a/app/views/withdrawal-claim.njk
+++ b/app/views/withdrawal-claim.njk
@@ -39,33 +39,7 @@
               classes: "govuk-fieldset__legend--m"
             }
           },
-          items: [
-            {
-              value: "vetSummaryEnteredIncorrectly",
-              text: "Data from the vet summary was entered incorrectly",
-              hint: { text: "For example, date of sample instead of date of visit" }
-            },
-            {
-              value: "differentClaimEntered",
-              text: "Data from a different claim was entered",
-              hint: { text: "For example, information from a follow-up instead of a review" }
-            },
-            {
-              value: "unintentionalTypingError",
-              text: "Data contained an unintentional typing error",
-              hint: { text: "For example, a spelling mistake or incorrect number" }
-            },
-            {
-              value: "incorrectSelectionInService",
-              text: "Incorrect selection was made in the digital service",
-              hint: { text: "For example, yes instead of no" }
-            },
-            {
-              value: "confusingInformationFromVet",
-              text: "Incorrect or confusing information was given by vet",
-              hint: { text: "For example, the wrong box completed in the summary template" }
-            }
-          ]
+          items: reasonForWithdrawalItems
         }) }}
 
         {{ govukRadios({
@@ -78,16 +52,7 @@
               classes: "govuk-fieldset__legend--m"
             }
           },
-          items: [
-            {
-              value: "customerContactedRPA",
-              text: "Customer contacted the RPA"
-            },
-            {
-              value: "evidenceDidNotMatch",
-              text: "Evidence did not match customer's data"
-            }
-          ]
+          items: issueDiscoveryItems
         }) }}
 
         {{ govukTextarea({

--- a/test/integration/narrow/routes/agreement.test.js
+++ b/test/integration/narrow/routes/agreement.test.js
@@ -12,7 +12,7 @@ import { getPagination, getPagingData } from "../../../../app/pagination.js";
 import { getClaimSearch } from "../../../../app/session/index.js";
 import { createServer } from "../../../../app/server.js";
 import { StatusCodes } from "http-status-codes";
-import { getClaimViewStates } from "../../../../app/routes/utils/get-claim-view-states.js";
+import { getApplicationStates } from "../../../../app/routes/utils/get-application-states.js";
 
 const { administrator } = permissions;
 
@@ -24,7 +24,7 @@ jest.mock("../../../../app/api/claims.js");
 jest.mock("../../../../app/api/contact-history.js");
 jest.mock("../../../../app/auth");
 jest.mock("../../../../app/session");
-jest.mock("../../../../app/routes/utils/get-claim-view-states");
+jest.mock("../../../../app/routes/utils/get-application-states");
 
 getApplication.mockReturnValue(applicationsData.applications[0]);
 getContactHistory.mockReturnValue(contactHistory);
@@ -45,7 +45,7 @@ displayContactHistory.mockReturnValue({
   farmerName: "NA",
   address: "NA",
 });
-getClaimViewStates.mockReturnValue({
+getApplicationStates.mockReturnValue({
   updateEligiblePiiRedactionAction: true,
   updateEligiblePiiRedactionForm: false,
 });
@@ -165,7 +165,7 @@ describe("Claims test", () => {
     });
 
     test("returns 200 and hides actions when user not super admin", async () => {
-      getClaimViewStates.mockReturnValue({
+      getApplicationStates.mockReturnValue({
         updateEligiblePiiRedactionAction: false, // driven by isSuperAdmin
         updateEligiblePiiRedactionForm: false,
       });

--- a/test/integration/narrow/routes/agreements-eligible-pii-redaction.test.js
+++ b/test/integration/narrow/routes/agreements-eligible-pii-redaction.test.js
@@ -9,7 +9,7 @@ import {
   updateEligiblePiiRedaction,
 } from "../../../../app/api/applications.js";
 import { getContactHistory, displayContactHistory } from "../../../../app/api/contact-history.js";
-import { getClaimViewStates } from "../../../../app/routes/utils/get-claim-view-states.js";
+import { getApplicationStates } from "../../../../app/routes/utils/get-application-states.js";
 import { getPagination, getPagingData } from "../../../../app/pagination.js";
 import { createServer } from "../../../../app/server.js";
 import { applicationsData } from "../../../data/applications.js";
@@ -22,7 +22,7 @@ jest.mock("../../../../app/api/applications");
 jest.mock("../../../../app/api/contact-history");
 jest.mock("../../../../app/pagination");
 jest.mock("../../../../app/routes/models/claim-list");
-jest.mock("../../../../app/routes/utils/get-claim-view-states");
+jest.mock("../../../../app/routes/utils/get-application-states");
 jest.mock("../../../../app/auth");
 
 getPagination.mockReturnValue({ limit: 10, offset: 0 });
@@ -57,7 +57,7 @@ describe("get-applications-to-redact", () => {
         farmerName: "NA",
         address: "NA",
       });
-      getClaimViewStates.mockReturnValue({});
+      getApplicationStates.mockReturnValue({});
     });
 
     test("returns 302 no auth", async () => {

--- a/test/integration/narrow/routes/models/application-history.test.js
+++ b/test/integration/narrow/routes/models/application-history.test.js
@@ -179,3 +179,56 @@ test("renders table", () => {
 
   expect(historyData).toEqual(expected);
 });
+
+test("renders withdrawal details as bold-titled lines in the action cell", () => {
+  const historyRecords = [
+    {
+      eventType: "status-updated",
+      updatedProperty: "status",
+      newValue: "WITHDRAWN",
+      note: "Withdrawal requested",
+      updatedBy: "Tester, A",
+      updatedAt: "2025-03-11T15:07:08.488Z",
+      withdrawal: {
+        reasonForWithdrawal: "vetSummaryEnteredIncorrectly",
+        issueDiscovery: "customerContactedRPA",
+        withdrawalDetails: "Date of sample was entered as the date of visit",
+      },
+    },
+  ];
+
+  const historyData = getHistoryDetails(historyRecords);
+
+  expect(historyData.rows[0][2]).toEqual({
+    html:
+      "Withdrawn<br>" +
+      "<strong>Reason for withdrawal:</strong> Data from the vet summary was entered incorrectly<br>" +
+      "<strong>How the issue was discovered:</strong> Customer contacted the RPA<br>" +
+      "<strong>Enter details for why this claim should be withdrawn:</strong> Date of sample was entered as the date of visit",
+  });
+});
+
+test("escapes html in the withdrawal details free text", () => {
+  const historyRecords = [
+    {
+      eventType: "status-updated",
+      updatedProperty: "status",
+      newValue: "WITHDRAWN",
+      note: "Withdrawal requested",
+      updatedBy: "Tester, A",
+      updatedAt: "2025-03-11T15:07:08.488Z",
+      withdrawal: {
+        reasonForWithdrawal: "unintentionalTypingError",
+        issueDiscovery: "evidenceDidNotMatch",
+        withdrawalDetails: "<script>alert('x')</script> & more",
+      },
+    },
+  ];
+
+  const historyData = getHistoryDetails(historyRecords);
+
+  expect(historyData.rows[0][2].html).toContain(
+    "<strong>Enter details for why this claim should be withdrawn:</strong> " +
+      "&lt;script&gt;alert(&#39;x&#39;)&lt;/script&gt; &amp; more",
+  );
+});

--- a/test/integration/narrow/routes/view-agreement.test.js
+++ b/test/integration/narrow/routes/view-agreement.test.js
@@ -5,6 +5,7 @@ import { oldWorldApplication } from "../../../data/ow-application.js";
 import { getApplication, getOldWorldApplicationHistory } from "../../../../app/api/applications.js";
 import { getContactHistory, displayContactHistory } from "../../../../app/api/contact-history.js";
 import { getClaimViewStates } from "../../../../app/routes/utils/get-claim-view-states.js";
+import { getApplicationStates } from "../../../../app/routes/utils/get-application-states.js";
 import { createServer } from "../../../../app/server.js";
 import { StatusCodes } from "http-status-codes";
 
@@ -13,6 +14,7 @@ const { administrator } = permissions;
 jest.mock("../../../../app/api/applications");
 jest.mock("../../../../app/api/contact-history");
 jest.mock("../../../../app/routes/utils/get-claim-view-states");
+jest.mock("../../../../app/routes/utils/get-application-states");
 jest.mock("../../../../app/auth");
 
 describe("View agreement (old world) test", () => {
@@ -40,6 +42,7 @@ describe("View agreement (old world) test", () => {
       address: "NA",
     });
     getClaimViewStates.mockReturnValue({});
+    getApplicationStates.mockReturnValue({});
   });
 
   test("returns 302 no auth", async () => {
@@ -61,6 +64,8 @@ describe("View agreement (old world) test", () => {
       updateVetsNameAction: true,
       updateVetRCVSNumberAction: true,
       updateDateOfVisitAction: true,
+    });
+    getApplicationStates.mockReturnValue({
       updateEligiblePiiRedactionAction: true,
     });
 

--- a/test/unit/routes/utils/get-form-flags.test.js
+++ b/test/unit/routes/utils/get-form-flags.test.js
@@ -17,7 +17,7 @@ test("opens none of the known forms when the key matches nothing", () => {
   }
 });
 
-test("covers every form flag getClaimViewStates reads", () => {
+test("covers every form flag getClaimViewStates and getApplicationStates read", () => {
   expect(Object.keys(getFormFlags("updateStatus"))).toEqual(
     expect.arrayContaining([
       "moveToInCheck",


### PR DESCRIPTION
Two main pieces of work: First, we only show the change buttons if we are not in a withdrawn state. Second, in the history tab, under the row of the withdrawal request, we show the reasons for it.