### PR TITLE
fix(logging): (AHWR-2187) stop jest leaking a pino transport worker #patch

### DIFF
--- a/app/logging/logger.js
+++ b/app/logging/logger.js
@@ -1,8 +1,11 @@
 import { pino } from "pino";
 import { loggerOptions } from "./logger-options.js";
 
-const logger = pino(loggerOptions);
+let logger;
 
 export function getLogger() {
+  if (!logger) {
+    logger = pino(loggerOptions);
+  }
   return logger;
 }

--- a/test/setup.js
+++ b/test/setup.js
@@ -1,3 +1,6 @@
 import { config } from "dotenv";
 
+// keep pino on ecs under test: a pino-pretty transport leaks a thread-stream worker
+process.env.USE_PRETTY_PRINT = "false";
+
 config();

--- a/test/unit/logging/logger-options.test.js
+++ b/test/unit/logging/logger-options.test.js
@@ -1,0 +1,62 @@
+import { loggerOptions } from "../../../app/logging/logger-options.js";
+import { config } from "../../../app/config/index.js";
+import { getTraceId } from "@defra/hapi-tracing";
+
+jest.mock("@defra/hapi-tracing", () => ({ getTraceId: jest.fn() }));
+
+describe("logger options", () => {
+  const env = process.env;
+
+  afterEach(() => {
+    process.env = env;
+  });
+
+  test("resolves the ecs log format when tests run, whatever the developer environment asks for", () => {
+    expect(config.logFormat).toBe("ecs");
+  });
+
+  test("still configures a pretty transport when the service itself runs with pretty printing on", () => {
+    jest.resetModules();
+    process.env = { ...env, USE_PRETTY_PRINT: "true" };
+
+    // re-required deliberately: a second module instance built against the flipped env
+    const { loggerOptions: prettyOptions } = require("../../../app/logging/logger-options.js");
+
+    expect(prettyOptions.transport).toEqual({
+      target: "pino-pretty",
+      options: { singleLine: true, colorize: true },
+    });
+  });
+
+  test("configures no transport, so no thread-stream worker is spawned", () => {
+    expect(loggerOptions).not.toHaveProperty("transport");
+  });
+
+  test("adds the trace id to every log line while a request is being traced", () => {
+    getTraceId.mockReturnValue("trace-1234");
+
+    expect(loggerOptions.mixin()).toEqual({ trace: { id: "trace-1234" } });
+  });
+
+  test("adds no trace to a log line when nothing is being traced", () => {
+    getTraceId.mockReturnValue(undefined);
+
+    expect(loggerOptions.mixin()).toEqual({});
+  });
+
+  test("serialises an Error into message, stack_trace and type", () => {
+    const error = new Error("test");
+
+    expect(loggerOptions.serializers.error(error)).toEqual({
+      message: "test",
+      stack_trace: error.stack,
+      type: "Error",
+    });
+  });
+
+  test("leaves a non-Error untouched when serialising", () => {
+    const notAnError = { some: "object" };
+
+    expect(loggerOptions.serializers.error(notAnError)).toBe(notAnError);
+  });
+});

--- a/test/unit/logging/logger.test.js
+++ b/test/unit/logging/logger.test.js
@@ -1,0 +1,44 @@
+import { getLogger } from "../../../app/logging/logger.js";
+
+describe("logger construction", () => {
+  const stubLogger = () => ({ info: jest.fn(), error: jest.fn() });
+
+  beforeEach(() => {
+    jest.resetModules();
+  });
+
+  test("does not construct a pino logger when the module is imported", () => {
+    const pino = jest.fn(stubLogger);
+    jest.doMock("pino", () => ({ pino }));
+
+    require("../../../app/logging/logger.js");
+
+    expect(pino).not.toHaveBeenCalled();
+  });
+
+  test("constructs the pino logger on the first getLogger call", () => {
+    const pino = jest.fn(stubLogger);
+    jest.doMock("pino", () => ({ pino }));
+
+    require("../../../app/logging/logger.js").getLogger();
+
+    expect(pino).toHaveBeenCalledTimes(1);
+  });
+
+  test("returns the same logger instance on every subsequent getLogger call", () => {
+    jest.doMock("pino", () => ({ pino: jest.fn(stubLogger) }));
+
+    const { getLogger: lazyGetLogger } = require("../../../app/logging/logger.js");
+
+    expect(lazyGetLogger()).toBe(lazyGetLogger());
+  });
+});
+
+describe("logger", () => {
+  test("getLogger returns a pino logger instance", () => {
+    const logger = getLogger();
+
+    expect(typeof logger.info).toBe("function");
+    expect(typeof logger.error).toBe("function");
+  });
+});


### PR DESCRIPTION
## Summary

Importing the logger constructed a pino instance at module scope. With pretty printing enabled, those options carry a transport, so pino spawns a thread-stream worker thread that nothing ever closes - one per jest worker. The result was "A worker process has failed to exit gracefully" on local test runs, a warning that trains everyone to ignore jest warnings generally.

Tests now pin the log format to ecs so no transport is ever built under test, and the logger is constructed on first use rather than on import.

## What Changed

- Test setup forces pretty printing off before dotenv loads, so no transport is built during any test run
- The logger is built lazily on first getLogger call, matching the pattern already used in ahwr-application-backend
- New unit tests cover lazy construction, the absence of a transport under test, and the trace id mixin on both branches
- A test asserts pretty printing still works when the service itself runs, so the transport cannot be removed by accident

## Why

The leak only bites where USE_PRETTY_PRINT is set in a local .env, which .env.example ships enabled. CI is unaffected: the compose test files set only NODE_ENV, and no .env reaches the container.