### PR TITLE
feat(forms): (AHWR-2190) prevent accidental double clicks on state-changing forms

### DIFF
--- a/app/views/includes/authorise-form.njk
+++ b/app/views/includes/authorise-form.njk
@@ -23,7 +23,8 @@
       errorMessage: errorMessages.confirm
     }) }}
     {{ govukButton({
-      text: "Confirm and continue"
+      text: "Confirm and continue",
+      preventDoubleClick: true
     }) }}
     <input type="hidden" name="reference" value="{{ reference }}" />
     <input type="hidden" name="page" value="{{ page }}" />

--- a/app/views/includes/create-flag.njk
+++ b/app/views/includes/create-flag.njk
@@ -41,7 +41,8 @@
       }) }}
 
     {{ govukButton({
-      text: "Create flag"
+      text: "Create flag",
+      preventDoubleClick: true
     }) }}
     <input type="hidden" name="crumb" value="{{ crumb }}"/>
     <input type="hidden" name="action" value="create"/>

--- a/app/views/includes/delete-flag.njk
+++ b/app/views/includes/delete-flag.njk
@@ -28,7 +28,8 @@
   
     {{ govukButton({
       text: "Delete flag",
-      classes: "govuk-button--warning"
+      classes: "govuk-button--warning",
+      preventDoubleClick: true
     }) }}
     <input type="hidden" name="crumb" value="{{ crumb }}"/>
     <input type="hidden" name="flagId" value="{{model.flagIdToDelete}}"/>

--- a/app/views/includes/eligible-pii-redaction-form.njk
+++ b/app/views/includes/eligible-pii-redaction-form.njk
@@ -44,7 +44,8 @@
     }}
     {{
       govukButton({
-        text: "Confirm and continue"
+        text: "Confirm and continue",
+        preventDoubleClick: true
       })
     }}
     <input type="hidden" name="reference" value="{{ reference }}" />

--- a/app/views/includes/recommend-to-pay-form.njk
+++ b/app/views/includes/recommend-to-pay-form.njk
@@ -23,7 +23,8 @@
       errorMessage: errorMessages.confirm
     }) }}
     {{ govukButton({
-      text: "Confirm and continue"
+      text: "Confirm and continue",
+      preventDoubleClick: true
     }) }}
     <input type="hidden" name="reference" value="{{ reference }}" />
     <input type="hidden" name="page" value="{{ page }}" />

--- a/app/views/includes/recommend-to-reject-form.njk
+++ b/app/views/includes/recommend-to-reject-form.njk
@@ -23,7 +23,8 @@
       errorMessage: errorMessages.confirm
     }) }}
     {{ govukButton({
-      text: "Confirm and continue"
+      text: "Confirm and continue",
+      preventDoubleClick: true
     }) }}
     <input type="hidden" name="reference" value="{{ reference }}" />
     <input type="hidden" name="page" value="{{ page }}" />

--- a/app/views/includes/reject-form.njk
+++ b/app/views/includes/reject-form.njk
@@ -23,7 +23,8 @@
       errorMessage: errorMessages.confirm
     }) }}
     {{ govukButton({
-      text: "Confirm and continue"
+      text: "Confirm and continue",
+      preventDoubleClick: true
     }) }}
     <input type="hidden" name="reference" value="{{ reference }}" />
     <input type="hidden" name="page" value="{{ page }}" />

--- a/app/views/includes/update-date-of-visit-form.njk
+++ b/app/views/includes/update-date-of-visit-form.njk
@@ -50,7 +50,8 @@
     }}
     {{
       govukButton({
-        text: "Confirm and continue"
+        text: "Confirm and continue",
+        preventDoubleClick: true
       })
     }}
     <input type="hidden" name="claimOrAgreement" value="{{ claimOrAgreement }}" />

--- a/app/views/includes/update-status-form.njk
+++ b/app/views/includes/update-status-form.njk
@@ -22,7 +22,8 @@
       errorMessage: errorMessages.note
     }) }}
     {{ govukButton({
-      text: "Confirm and continue"
+      text: "Confirm and continue",
+      preventDoubleClick: true
     }) }}
     <input type="hidden" name="reference" value="{{ reference }}" />
     <input type="hidden" name="page" value="{{ page }}" />

--- a/app/views/includes/update-vet-rcvs-number-form.njk
+++ b/app/views/includes/update-vet-rcvs-number-form.njk
@@ -31,7 +31,8 @@
     }}
     {{
       govukButton({
-        text: "Confirm and continue"
+        text: "Confirm and continue",
+        preventDoubleClick: true
       })
     }}
     <input type="hidden" name="claimOrAgreement" value="{{ claimOrAgreement }}" />

--- a/app/views/includes/update-vets-name-form.njk
+++ b/app/views/includes/update-vets-name-form.njk
@@ -31,7 +31,8 @@
     }}
     {{
       govukButton({
-        text: "Confirm and continue"
+        text: "Confirm and continue",
+        preventDoubleClick: true
       })
     }}
     <input type="hidden" name="claimOrAgreement" value="{{ claimOrAgreement }}" />

--- a/app/views/withdrawal-claim.njk
+++ b/app/views/withdrawal-claim.njk
@@ -70,7 +70,8 @@
         <div class="govuk-button-group">
           {{ govukButton({
             text: "Withdraw claim",
-            classes: "govuk-button--warning"
+            classes: "govuk-button--warning",
+            preventDoubleClick: true
           }) }}
           {{ govukButton({
             text: "Do not withdraw claim",

--- a/test/integration/narrow/routes/agreement.test.js
+++ b/test/integration/narrow/routes/agreement.test.js
@@ -13,6 +13,7 @@ import { getClaimSearch } from "../../../../app/session/index.js";
 import { createServer } from "../../../../app/server.js";
 import { StatusCodes } from "http-status-codes";
 import { getApplicationStates } from "../../../../app/routes/utils/get-application-states.js";
+import { doubleClickProtectionOk } from "../../../utils/double-click-protection-expect.js";
 
 const { administrator } = permissions;
 
@@ -142,6 +143,26 @@ describe("Claims test", () => {
         )
         .first();
       expect(redactionRow.find(".govuk-summary-list__value p").text().trim()).toBe("No");
+    });
+
+    test("the eligible for PII redaction form prevents an accidental double click", async () => {
+      getApplicationStates.mockReturnValueOnce({
+        updateEligiblePiiRedactionAction: true,
+        updateEligiblePiiRedactionForm: true,
+      });
+      getApplication.mockReturnValue({
+        ...applicationsData.applications[0],
+        redacted: false,
+      });
+      const options = {
+        method: "GET",
+        url: `${url}?page=1`,
+        auth,
+      };
+
+      const res = await server.inject(options);
+
+      doubleClickProtectionOk(cheerio.load(res.payload), 1);
     });
 
     test("returns 200 and hides actions when agreement is redacted", async () => {

--- a/test/integration/narrow/routes/flags.test.js
+++ b/test/integration/narrow/routes/flags.test.js
@@ -8,6 +8,7 @@ import { flags } from "../../../data/flags.js";
 import { StatusCodes } from "http-status-codes";
 import { mapAuth } from "../../../../app/auth/map-auth.js";
 import { createServer } from "../../../../app/server.js";
+import { doubleClickProtectionOk } from "../../../utils/double-click-protection-expect.js";
 
 const { administrator, user } = permissions;
 
@@ -252,6 +253,32 @@ describe("Flags tests", () => {
 
       expect($(".ahwr-update-form").length).toBe(0);
       phaseBannerOk($);
+    });
+
+    test("the create flag form prevents an accidental double click", async () => {
+      const options = {
+        method: "GET",
+        url: "/flags?createFlag=true",
+        auth,
+        headers: { cookie: `crumb=${crumb}` },
+      };
+
+      const res = await server.inject(options);
+
+      doubleClickProtectionOk(cheerio.load(res.payload), 1);
+    });
+
+    test("the delete flag form prevents an accidental double click", async () => {
+      const options = {
+        method: "GET",
+        url: "/flags?deleteFlag=abc123",
+        auth,
+        headers: { cookie: `crumb=${crumb}` },
+      };
+
+      const res = await server.inject(options);
+
+      doubleClickProtectionOk(cheerio.load(res.payload), 1);
     });
   });
 

--- a/test/integration/narrow/routes/view-claim.test.js
+++ b/test/integration/narrow/routes/view-claim.test.js
@@ -6,6 +6,7 @@ import { getApplication } from "../../../../app/api/applications.js";
 import { createServer } from "../../../../app/server.js";
 import { StatusCodes } from "http-status-codes";
 import { getClaimViewStates } from "../../../../app/routes/utils/get-claim-view-states.js";
+import { doubleClickProtectionOk } from "../../../utils/double-click-protection-expect.js";
 const { administrator } = permissions;
 
 jest.mock("../../../../app/routes/utils/get-claim-view-states");
@@ -883,6 +884,32 @@ describe("View claim test", () => {
         expect($(".govuk-summary-list__key").text()).toMatch(expected.key);
         expect($(".govuk-summary-list__value").text()).toMatch(expected.value);
       }
+    });
+
+    test("every state-changing form prevents an accidental double click", async () => {
+      const options = {
+        method: "GET",
+        url: `${url}/AHWR-0000-4444`,
+        auth,
+      };
+      getClaim.mockReturnValue(claims[1]);
+      getClaims.mockReturnValue({ claims });
+      getApplication.mockReturnValue(application);
+      getClaimViewStates.mockReturnValueOnce({
+        moveToInCheckForm: true,
+        recommendToPayForm: true,
+        recommendToRejectForm: true,
+        authoriseForm: true,
+        rejectForm: true,
+        updateStatusForm: true,
+        updateVetsNameForm: true,
+        updateVetRCVSNumberForm: true,
+        updateDateOfVisitForm: true,
+      });
+
+      const res = await server.inject(options);
+
+      doubleClickProtectionOk(cheerio.load(res.payload), 9);
     });
   });
 

--- a/test/integration/narrow/routes/withdrawal-claim.test.js
+++ b/test/integration/narrow/routes/withdrawal-claim.test.js
@@ -6,6 +6,7 @@ import { StatusCodes } from "http-status-codes";
 import { config } from "../../../../app/config/index.js";
 import { getClaim, withdrawClaim } from "../../../../app/api/claims.js";
 import { getApplication } from "../../../../app/api/applications.js";
+import { doubleClickProtectionOk } from "../../../utils/double-click-protection-expect.js";
 
 const SUPER_ADMIN_USERNAME = "superadmin@test";
 
@@ -101,6 +102,16 @@ describe("Withdrawal claim page", () => {
       expect($("form").attr("action")).toBe(`/withdraw-claim/${reference}`);
       expect($(".govuk-button--secondary").attr("href")).toBe(viewClaimUrl);
       expect($(".govuk-back-link").attr("href")).toBe(viewClaimUrl);
+    });
+
+    test("the withdrawal form prevents an accidental double click", async () => {
+      const res = await server.inject({
+        method: "GET",
+        url: `/withdraw-claim/${reference}?page=2&returnPage=claims`,
+        auth: adminAuth,
+      });
+
+      doubleClickProtectionOk(cheerio.load(res.payload), 1);
     });
 
     test("forbids a non-administrator", async () => {

--- a/test/utils/double-click-protection-expect.js
+++ b/test/utils/double-click-protection-expect.js
@@ -1,0 +1,8 @@
+// ahwr-update-form marks the forms that mutate an agreement, claim or flag
+export const doubleClickProtectionOk = ($, expectedFormCount) => {
+  const protection = $("form.ahwr-update-form button[type='submit']")
+    .map((_, button) => $(button).attr("data-prevent-double-click") ?? "unprotected")
+    .get();
+
+  expect(protection).toEqual(Array(expectedFormCount).fill("true"));
+};


### PR DESCRIPTION
## Summary

First of three PRs on this branch's workstream.

Adds the GOV.UK Frontend double-click protection to every form that mutates an agreement, claim or flag. This is purely additive and independently deployable - no existing behaviour is removed or changed. It goes in first so that the bespoke duplicate-submission guard can be removed in the next PR without leaving any deployed state in which neither protection is present.

## What Changed

- Added `preventDoubleClick: true` to the submit button on 12 state-changing forms: authorise, recommend to pay, recommend to reject, reject, update status, create flag, delete flag, update date of visit, update vet's name, update vet RCVS number, eligible for PII redaction, and withdraw claim.
- Left the search and support forms alone. Resubmitting a search is harmless.
- `move-to-in-check-form` already had the option and is unchanged.
- Added a `doubleClickProtectionOk` test helper in `test/utils/`, following the existing `phase-banner-expect.js` pattern, keyed on the `ahwr-update-form` class that already marks the mutating forms.
- Added 5 integration tests covering all 13 mutating forms across the view claim, agreement, flags and withdrawal pages.

## Why

The backoffice guards against duplicate submissions by rotating the CSRF token and caching it for 24 hours. That rotation is what causes form submissions to fail with a 403 when more than one tab is open, since only the most recently rendered page holds a token matching the cookie. The guard is also largely redundant: the application backend already no-ops an identical repeat request on six of its seven mutating endpoints.

The fix is to stop rotating the token and remove the guard, but that protection needs replacing first. The public user UI has used `preventDoubleClick` for this since the outset, in 65 templates. The backoffice already loads govuk-frontend, already calls `initAll()`, and already used the option in exactly one form. This PR brings the remaining forms into line before anything is taken away.