### PR TITLE
fix: (ahwr-2185) correct count

### DIFF
--- a/app/lib/get-claim-breakdown.js
+++ b/app/lib/get-claim-breakdown.js
@@ -1,9 +1,13 @@
+import { STATUS } from "ffc-ahwr-common-library";
+
+const isNotWithdrawn = (claim) => claim.status !== STATUS.WITHDRAWN;
+
 export const getHerdBreakdown = (claims) => {
   const initialBreakdown = { beef: 0, sheep: 0, dairy: 0, pigs: 0 };
   const countedHerdIds = new Set();
   const countedSpeciesWithoutHerd = new Set();
 
-  for (const claim of claims) {
+  for (const claim of claims.filter(isNotWithdrawn)) {
     if (claim.herd?.id) {
       const { id: herdId } = claim.herd;
       const species = claim.data.typeOfLivestock;
@@ -28,7 +32,7 @@ export const getHerdBreakdown = (claims) => {
 export const getSiteBreakdown = (claims) => {
   const siteIds = new Set();
 
-  for (const claim of claims) {
+  for (const claim of claims.filter(isNotWithdrawn)) {
     if (claim.herd?.id) {
       siteIds.add(claim.herd.id);
     }

--- a/app/lib/get-claim-breakdown.test.js
+++ b/app/lib/get-claim-breakdown.test.js
@@ -1,4 +1,7 @@
+import { STATUS } from "ffc-ahwr-common-library";
 import { getHerdBreakdown, getSiteBreakdown } from "./get-claim-breakdown.js";
+
+const withdrawn = (claim) => ({ ...claim, status: STATUS.WITHDRAWN });
 
 const sheepClaimOneWithSheepiesHerd = {
   id: "4e62d9cb-0046-421e-8296-7051a584723b",
@@ -228,6 +231,16 @@ describe("getSiteBreakdown", () => {
     const result = getSiteBreakdown([]);
     expect(result).toEqual({ poultryBreakdown: { amount: 0 } });
   });
+
+  test("does not count a site only referenced by withdrawn claims", () => {
+    const result = getSiteBreakdown([withdrawn(poultryClaim), secondPoultryClaim]);
+    expect(result).toEqual({ poultryBreakdown: { amount: 1 } });
+  });
+
+  test("counts a site referenced by both a withdrawn and a live claim", () => {
+    const result = getSiteBreakdown([withdrawn(poultryClaim), repeatedSitePoultryClaim]);
+    expect(result).toEqual({ poultryBreakdown: { amount: 1 } });
+  });
 });
 
 describe("getHerdBreakdown", () => {
@@ -289,6 +302,55 @@ describe("getHerdBreakdown", () => {
 
     expect(result).toEqual({
       herdBreakdown: { beef: 2, dairy: 0, pigs: 1, sheep: 1 },
+    });
+  });
+
+  test("it does not count a herd only referenced by withdrawn claims", () => {
+    const strippedDownClaims = [
+      withdrawn(sheepClaimOneWithSheepiesHerd),
+      pigsClaimWithHerd,
+      beefClaimWithHerd,
+    ];
+    const result = getHerdBreakdown(strippedDownClaims);
+
+    expect(result).toEqual({
+      herdBreakdown: { beef: 1, dairy: 0, pigs: 1, sheep: 0 },
+    });
+  });
+
+  test("it counts a herd referenced by both a withdrawn and a live claim", () => {
+    const strippedDownClaims = [
+      withdrawn(sheepClaimOneWithSheepiesHerd),
+      sheepClaimTwoWithSheepiesHerd,
+      pigsClaimWithHerd,
+    ];
+    const result = getHerdBreakdown(strippedDownClaims);
+
+    expect(result).toEqual({
+      herdBreakdown: { beef: 0, dairy: 0, pigs: 1, sheep: 1 },
+    });
+  });
+
+  test("it does not count an unnamed herd whose only claim is withdrawn", () => {
+    const strippedDownClaims = [withdrawn(beefClaimNoHerd), pigsClaimWithNoHerd];
+    const result = getHerdBreakdown(strippedDownClaims);
+
+    expect(result).toEqual({
+      herdBreakdown: { beef: 0, dairy: 0, pigs: 1, sheep: 0 },
+    });
+  });
+
+  test("it returns an empty breakdown when every claim is withdrawn", () => {
+    const strippedDownClaims = [
+      withdrawn(sheepClaimOneWithSheepiesHerd),
+      withdrawn(pigsClaimWithHerd),
+      withdrawn(beefClaimWithHerd),
+      withdrawn(beefClaimNoHerd),
+    ];
+    const result = getHerdBreakdown(strippedDownClaims);
+
+    expect(result).toEqual({
+      herdBreakdown: { beef: 0, dairy: 0, pigs: 0, sheep: 0 },
     });
   });
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -43,6 +43,7 @@
         "@babel/plugin-transform-export-namespace-from": "7.27.1",
         "@babel/plugin-transform-modules-commonjs": "7.28.6",
         "@pact-foundation/pact": "17.0.1",
+        "@types/jest": "30.0.0",
         "babel-jest": "30.2.0",
         "cheerio": "1.0.0",
         "clean-webpack-plugin": "4.0.0",
@@ -5903,6 +5904,17 @@
       "license": "MIT",
       "dependencies": {
         "@types/istanbul-lib-report": "*"
+      }
+    },
+    "node_modules/@types/jest": {
+      "version": "30.0.0",
+      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-30.0.0.tgz",
+      "integrity": "sha512-XTYugzhuwqWjws0CVz8QpM36+T+Dz5mTEBKhNs/esGLnCIlGdRy+Dq78NRjd7ls7r8BC8ZRMOrKlkO1hU0JOwA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "expect": "^30.0.0",
+        "pretty-format": "^30.0.0"
       }
     },
     "node_modules/@types/jsdom": {

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "@babel/plugin-transform-export-namespace-from": "7.27.1",
     "@babel/plugin-transform-modules-commonjs": "7.28.6",
     "@pact-foundation/pact": "17.0.1",
+    "@types/jest": "30.0.0",
     "babel-jest": "30.2.0",
     "cheerio": "1.0.0",
     "clean-webpack-plugin": "4.0.0",

--- a/test/integration/narrow/routes/agreement.test.js
+++ b/test/integration/narrow/routes/agreement.test.js
@@ -570,6 +570,66 @@ describe("Claims test", () => {
       // Same herd id used 3 times should only count as 1
       expect(sheepRow.find(".govuk-summary-list__value").text().trim()).toBe("1");
     });
+
+    test("excludes herds that only appear in withdrawn claims", async () => {
+      const claimsWithWithdrawnHerd = [
+        {
+          ...baseClaim,
+          reference: "RESH-LIVE-0001",
+          data: { ...baseClaim.data, typeOfLivestock: "sheep" },
+          herd: { id: "herd-sheep-live" },
+        },
+        {
+          ...baseClaim,
+          reference: "RESH-GONE-0002",
+          status: "WITHDRAWN",
+          data: { ...baseClaim.data, typeOfLivestock: "sheep" },
+          herd: { id: "herd-sheep-withdrawn" },
+        },
+        {
+          ...baseClaim,
+          reference: "REPI-GONE-0003",
+          status: "WITHDRAWN",
+          data: { ...baseClaim.data, typeOfLivestock: "pigs" },
+          herd: { id: "herd-pigs-withdrawn" },
+        },
+      ];
+
+      getClaims.mockReturnValueOnce({
+        total: claimsWithWithdrawnHerd.length,
+        claims: claimsWithWithdrawnHerd,
+      });
+
+      const options = {
+        method: "GET",
+        url: `${url}?page=1`,
+        auth,
+      };
+
+      const res = await server.inject(options);
+      const $ = cheerio.load(res.payload);
+
+      expect(res.statusCode).toBe(StatusCodes.OK);
+
+      const herdBreakdownRows = $(
+        ".govuk-summary-list .govuk-summary-list .govuk-summary-list__row",
+      );
+
+      const sheepRow = herdBreakdownRows.filter((_, el) =>
+        $(el).find(".govuk-summary-list__key").text().includes("Sheep"),
+      );
+      const pigsRow = herdBreakdownRows.filter((_, el) =>
+        $(el).find(".govuk-summary-list__key").text().includes("Pigs"),
+      );
+
+      // Only the sheep herd with a live claim is counted
+      expect(sheepRow.find(".govuk-summary-list__value").text().trim()).toBe("1");
+      expect(pigsRow.find(".govuk-summary-list__value").text().trim()).toBe("0");
+
+      // The withdrawn claims are still listed in the claims table
+      expect($(".govuk-table__body").text()).toContain("RESH-GONE-0002");
+      expect($(".govuk-table__body").text()).toContain("REPI-GONE-0003");
+    });
   });
 
   describe("poultry site breakdown display", () => {
@@ -670,6 +730,43 @@ describe("Claims test", () => {
         $(el).find(".govuk-summary-list__key").text().includes("Number of sites"),
       );
       expect(sitesRow.find(".govuk-summary-list__value").text().trim()).toBe("2");
+    });
+
+    test("excludes sites that only appear in withdrawn claims", async () => {
+      const poultryClaimsWithWithdrawnSite = [
+        { ...poultryClaim, reference: "PORE-LIVE-0001", herd: { id: "site-1-id" } },
+        {
+          ...poultryClaim,
+          reference: "PORE-GONE-0002",
+          status: "WITHDRAWN",
+          herd: { id: "site-2-id" },
+        },
+      ];
+
+      getApplication.mockReturnValueOnce(poultryApplication);
+      getClaims.mockReturnValueOnce({
+        total: poultryClaimsWithWithdrawnSite.length,
+        claims: poultryClaimsWithWithdrawnSite,
+      });
+
+      const options = {
+        method: "GET",
+        url: `${poultryUrl}?page=1`,
+        auth,
+      };
+
+      const res = await server.inject(options);
+      const $ = cheerio.load(res.payload);
+
+      expect(res.statusCode).toBe(StatusCodes.OK);
+
+      const sitesRow = $(".govuk-summary-list__row").filter((_, el) =>
+        $(el).find(".govuk-summary-list__key").text().includes("Number of sites"),
+      );
+      expect(sitesRow.find(".govuk-summary-list__value").text().trim()).toBe("1");
+
+      // The withdrawn claim is still listed in the claims table
+      expect($(".govuk-table__body").text()).toContain("PORE-GONE-0002");
     });
 
     test("displays zero sites when no poultry claims have herd", async () => {

--- a/test/integration/narrow/routes/view-claim.test.js
+++ b/test/integration/narrow/routes/view-claim.test.js
@@ -1141,6 +1141,58 @@ describe("View claim test", () => {
       // Same herd id used 3 times should only count as 1
       expect(sheepRow.find(".govuk-summary-list__value").text().trim()).toBe("1");
     });
+
+    test("excludes herds that only appear in withdrawn claims", async () => {
+      const options = {
+        method: "GET",
+        url: `${url}/AHWR-0000-4444`,
+        auth,
+      };
+
+      const claimsWithWithdrawnHerd = [
+        {
+          ...claims[0],
+          data: { ...claims[0].data, typeOfLivestock: "sheep" },
+          herd: { id: "herd-sheep-live" },
+        },
+        {
+          ...claims[0],
+          status: "WITHDRAWN",
+          data: { ...claims[0].data, typeOfLivestock: "sheep" },
+          herd: { id: "herd-sheep-withdrawn" },
+        },
+        {
+          ...claims[0],
+          status: "WITHDRAWN",
+          data: { ...claims[0].data, typeOfLivestock: "pigs" },
+          herd: { id: "herd-pigs-withdrawn" },
+        },
+      ];
+
+      getClaim.mockReturnValue(claims[0]);
+      getClaims.mockReturnValue({ claims: claimsWithWithdrawnHerd });
+      getApplication.mockReturnValue(application);
+
+      const res = await server.inject(options);
+      const $ = cheerio.load(res.payload);
+
+      expect(res.statusCode).toBe(StatusCodes.OK);
+
+      const herdBreakdownRows = $(
+        ".govuk-summary-list .govuk-summary-list .govuk-summary-list__row",
+      );
+
+      const sheepRow = herdBreakdownRows.filter((_, el) =>
+        $(el).find(".govuk-summary-list__key").text().includes("Sheep"),
+      );
+      const pigsRow = herdBreakdownRows.filter((_, el) =>
+        $(el).find(".govuk-summary-list__key").text().includes("Pigs"),
+      );
+
+      // Only the sheep herd with a live claim is counted
+      expect(sheepRow.find(".govuk-summary-list__value").text().trim()).toBe("1");
+      expect(pigsRow.find(".govuk-summary-list__value").text().trim()).toBe("0");
+    });
   });
 
   describe("poultry site breakdown display", () => {
@@ -1242,6 +1294,33 @@ describe("View claim test", () => {
         $(el).find(".govuk-summary-list__key").text().includes("Number of sites"),
       );
       expect(sitesRow.find(".govuk-summary-list__value").text().trim()).toBe("2");
+    });
+
+    test("excludes sites that only appear in withdrawn claims", async () => {
+      const options = {
+        method: "GET",
+        url: `${url}/PORE-1111-6666`,
+        auth,
+      };
+
+      const poultryClaimsWithWithdrawnSite = [
+        { ...poultryClaim, herd: { id: "site-1-id" } },
+        { ...poultryClaim, status: "WITHDRAWN", herd: { id: "site-2-id" } },
+      ];
+
+      getClaim.mockReturnValue(poultryClaim);
+      getClaims.mockReturnValue({ claims: poultryClaimsWithWithdrawnSite });
+      getApplication.mockReturnValue(poultryApplication);
+
+      const res = await server.inject(options);
+      const $ = cheerio.load(res.payload);
+
+      expect(res.statusCode).toBe(StatusCodes.OK);
+
+      const sitesRow = $(".govuk-summary-list__row").filter((_, el) =>
+        $(el).find(".govuk-summary-list__key").text().includes("Number of sites"),
+      );
+      expect(sitesRow.find(".govuk-summary-list__value").text().trim()).toBe("1");
     });
 
     test("displays zero sites when no poultry claims have herd", async () => {


### PR DESCRIPTION
Herd/sites that only appear on withdraw claims should not be counted for the totals that appear on the view-claim and the agreement pages.

Added @types/jest for the benefit of LSPs