### PR TITLE
fix(csrf): (AHWR-2190) stop rotating the crumb so multi-tab submissions work

### DIFF
--- a/app/routes/agreement.js
+++ b/app/routes/agreement.js
@@ -1,6 +1,5 @@
 import joi from "joi";
 import boom from "@hapi/boom";
-import { generateNewCrumb } from "./utils/crumb-cache.js";
 import { permissions } from "../auth/permissions.js";
 import { getApplication } from "../api/applications.js";
 import { formattedDateToUk, upperFirstLetter } from "../lib/display-helper.js";
@@ -109,7 +108,6 @@ export const buildAgreement = async (
 ) => {
   const applicationReference = reference;
 
-  await generateNewCrumb(request, h);
   const application = await getApplication(applicationReference, request.logger);
   const contactHistory = await getContactHistory(applicationReference, request.logger);
   const contactHistoryDetails = displayContactHistory(contactHistory);

--- a/app/routes/agreements-eligible-pii-redaction.js
+++ b/app/routes/agreements-eligible-pii-redaction.js
@@ -1,5 +1,4 @@
 import joi from "joi";
-import { generateNewCrumb } from "./utils/crumb-cache.js";
 import { permissions } from "../auth/permissions.js";
 import { updateEligiblePiiRedaction } from "../api/applications.js";
 import { formatErrorsForUI } from "./utils/format-errors-for-ui.js";
@@ -52,7 +51,6 @@ export const updateEligiblePiiRedactionRoute = {
       const { name } = request.auth.credentials.account;
       const { page, note, reference, eligiblePiiRedaction } = request.payload;
 
-      await generateNewCrumb(request, h);
       const query = new URLSearchParams({ page });
 
       const agreementData = {

--- a/app/routes/agreements.js
+++ b/app/routes/agreements.js
@@ -6,7 +6,6 @@ import { sessionKeys } from "../session/keys.js";
 import { viewModel } from "./models/application-list.js";
 import { searchValidation } from "../lib/search-validation.js";
 import { extractDateRangeParts, emptyDateParts } from "./utils/date-filter.js";
-import { generateNewCrumb } from "./utils/crumb-cache.js";
 import { FLAG, AGREEMENT_STATUS, AGREEMENT_TYPE } from "../constants/index.js";
 import { StatusCodes } from "http-status-codes";
 
@@ -30,7 +29,6 @@ export const agreementsRoutes = [
         }),
       },
       handler: async (request, h) => {
-        await generateNewCrumb(request, h);
         const viewModelDetails = await viewModel(request);
         return h.view(viewTemplate, viewModelDetails);
       },

--- a/app/routes/claim/build-update-claim-route.js
+++ b/app/routes/claim/build-update-claim-route.js
@@ -1,7 +1,6 @@
 import { formatErrorsForUI } from "../utils/format-errors-for-ui.js";
 import { getFormFlags } from "../utils/get-form-flags.js";
 import { buildViewClaim } from "../view-claim.js";
-import { generateNewCrumb } from "../utils/crumb-cache.js";
 import { updateClaimStatus } from "../../api/claims.js";
 import Joi from "joi";
 
@@ -25,8 +24,6 @@ export const updateClaimHandler = async (request, h, status) => {
   const { name } = request.auth.credentials.account;
 
   const logger = request.logger.child({ reference });
-
-  await generateNewCrumb(request, h);
 
   const query = new URLSearchParams({ page });
   query.append("returnPage", returnPage);

--- a/app/routes/claims-data.js
+++ b/app/routes/claims-data.js
@@ -1,5 +1,4 @@
 import joi from "joi";
-import { generateNewCrumb } from "./utils/crumb-cache.js";
 import { permissions } from "../auth/permissions.js";
 import { updateClaimData } from "../api/claims.js";
 import { updateApplicationData } from "../api/applications.js";
@@ -173,7 +172,6 @@ export const claimsDataRoutes = [
           return renderErrAtView(request, h, err);
         }
 
-        await generateNewCrumb(request, h);
         const query = new URLSearchParams({ page });
 
         if (claimOrAgreement === "claim") {

--- a/app/routes/claims.js
+++ b/app/routes/claims.js
@@ -1,7 +1,6 @@
 import joi from "joi";
 import { getClaimSearch, setClaimSearch } from "../session/index.js";
 import { sessionKeys } from "../session/keys.js";
-import { generateNewCrumb } from "./utils/crumb-cache.js";
 import { config } from "../config/index.js";
 import { getClaims } from "../api/claims.js";
 import { getPagination, getPagingData } from "../pagination.js";
@@ -130,7 +129,6 @@ export const claimsRoutes = [
       },
       handler: async (request, h) => {
         try {
-          await generateNewCrumb(request, h);
           const viewData = await getViewData(request);
           return h.view("claims", viewData);
         } catch (err) {
@@ -175,7 +173,6 @@ export const claimsRoutes = [
       },
       handler: async (request, h) => {
         try {
-          await generateNewCrumb(request, h);
           setClaimSearch(request, claimSearch.searchText, "");
           setClaimSearch(request, claimSearch.searchType, "");
           setClaimSearch(request, claimSearch.agreementType, AGREEMENT_TYPE.ALL);

--- a/app/routes/flags.js
+++ b/app/routes/flags.js
@@ -1,6 +1,5 @@
 import Joi from "joi";
 import { permissions } from "../auth/permissions.js";
-import { generateNewCrumb } from "./utils/crumb-cache.js";
 import { createFlagsTableData } from "./models/flags-list.js";
 import { deleteFlag as deleteFlagApiCall, createFlag as createFlagApiCall } from "../api/flags.js";
 import { StatusCodes } from "http-status-codes";
@@ -27,7 +26,6 @@ const ERRORS = {
 };
 
 const createView = async (request, h, deleteFlagId, createFlag, errors) => {
-  await generateNewCrumb(request, h);
   const { isAdministrator, isSuperAdmin } = mapAuth(request);
 
   // check if user is allowed to create/delete flags

--- a/app/routes/utils/crumb-cache.js
+++ b/app/routes/utils/crumb-cache.js
@@ -1,4 +1,0 @@
-export const generateNewCrumb = async (request, h) => {
-  request.plugins.crumb = null;
-  await request.server.plugins.crumb.generate(request, h);
-};

--- a/app/routes/withdrawal-claim.js
+++ b/app/routes/withdrawal-claim.js
@@ -2,7 +2,6 @@ import joi from "joi";
 import boom from "@hapi/boom";
 import { StatusCodes } from "http-status-codes";
 import { permissions } from "../auth/permissions.js";
-import { generateNewCrumb } from "./utils/crumb-cache.js";
 import { getErrorMessagesByKey } from "./utils/get-error-messages-by-key.js";
 import { canWithdrawClaim } from "./utils/can-withdraw-claim.js";
 import { mapAuth } from "../auth/map-auth.js";
@@ -137,7 +136,6 @@ export const withdrawalClaimPostRoute = {
         { reasonForWithdrawal, issueDiscovery, withdrawalDetails },
         request.logger,
       );
-      await generateNewCrumb(request, h);
       return h.redirect(viewClaimLink(reference, page, returnPage));
     },
   },

--- a/test/integration/narrow/routes/crumb.test.js
+++ b/test/integration/narrow/routes/crumb.test.js
@@ -1,0 +1,85 @@
+import { permissions } from "../../../../app/auth/permissions.js";
+import { getPagination } from "../../../../app/pagination.js";
+import { getApplications } from "../../../../app/api/applications.js";
+import { applicationsData } from "../../../data/applications.js";
+import { createServer } from "../../../../app/server.js";
+import { StatusCodes } from "http-status-codes";
+
+jest.mock("../../../../app/session");
+jest.mock("../../../../app/api/applications");
+jest.mock("../../../../app/pagination");
+jest.mock("../../../../app/auth");
+
+const { administrator } = permissions;
+
+getPagination.mockReturnValue({ limit: 10, offset: 0 });
+getApplications.mockReturnValue(applicationsData);
+
+// server.inject keeps no cookie jar, so the browser's crumb cookie is threaded through by hand
+const crumbCookie = (response) =>
+  (response.headers["set-cookie"] ?? []).find((cookie) => cookie.startsWith("crumb="));
+
+const crumbValue = (response) => /crumb=([^;]*)/.exec(crumbCookie(response) ?? "")?.[1];
+
+describe("CSRF crumb", () => {
+  const url = "/agreements";
+  const auth = {
+    strategy: "session-auth",
+    credentials: { scope: [administrator], account: { username: "test user" } },
+  };
+
+  let server;
+
+  beforeAll(async () => {
+    server = await createServer();
+  });
+
+  const renderPage = (crumb) =>
+    server.inject({
+      method: "GET",
+      url,
+      auth,
+      ...(crumb && { headers: { cookie: `crumb=${crumb}` } }),
+    });
+
+  const submitSearch = ({ formCrumb, cookie }) =>
+    server.inject({
+      method: "POST",
+      url,
+      auth,
+      payload: { submit: "advancedSearch", crumb: formCrumb },
+      headers: { cookie: `crumb=${cookie}` },
+    });
+
+  test("issues no new crumb when a page is rendered again", async () => {
+    const firstRender = await renderPage();
+
+    const secondRender = await renderPage(crumbValue(firstRender));
+
+    expect(crumbCookie(secondRender)).toBeUndefined();
+  });
+
+  test("accepts a search submitted from a page rendered before another page loaded", async () => {
+    const tabA = await renderPage();
+    const crumbShownInTabA = crumbValue(tabA);
+    const tabB = await renderPage(crumbShownInTabA);
+
+    const res = await submitSearch({
+      formCrumb: crumbShownInTabA,
+      cookie: crumbValue(tabB) ?? crumbShownInTabA,
+    });
+
+    expect(res.statusCode).toBe(StatusCodes.OK);
+  });
+
+  test("rejects a search submitted with a crumb that does not match the cookie", async () => {
+    const render = await renderPage();
+
+    const res = await submitSearch({
+      formCrumb: "not-the-crumb-issued-for-this-session",
+      cookie: crumbValue(render),
+    });
+
+    expect(res.statusCode).toBe(StatusCodes.FORBIDDEN);
+  });
+});

--- a/test/integration/narrow/routes/recommend-to-pay.test.js
+++ b/test/integration/narrow/routes/recommend-to-pay.test.js
@@ -1,13 +1,11 @@
 import { permissions } from "../../../../app/auth/permissions.js";
 import { getCrumbs } from "../../../utils/get-crumbs.js";
 import { createServer } from "../../../../app/server.js";
-import { generateNewCrumb } from "../../../../app/routes/utils/crumb-cache.js";
 import { setupViewClaimRender } from "../../../utils/view-claim-render-fixtures.js";
 import { StatusCodes } from "http-status-codes";
 
 jest.mock("../../../../app/api/claims");
 jest.mock("../../../../app/api/applications");
-jest.mock("../../../../app/routes/utils/crumb-cache");
 jest.mock("../../../../app/routes/utils/get-claim-view-states");
 jest.mock("../../../../app/auth");
 
@@ -93,7 +91,6 @@ describe("Recommended To Pay test", () => {
         };
         const res = await server.inject(options);
         expect(res.statusCode).toBe(StatusCodes.MOVED_TEMPORARILY);
-        expect(generateNewCrumb).toHaveBeenCalledTimes(1);
         expect(res.headers.location).toEqual(`/view-claim/${reference}?page=1&returnPage=claims`);
       },
     );

--- a/test/integration/narrow/routes/recommend-to-reject.test.js
+++ b/test/integration/narrow/routes/recommend-to-reject.test.js
@@ -1,6 +1,5 @@
 import { StatusCodes } from "http-status-codes";
 import { permissions } from "../../../../app/auth/permissions.js";
-import { generateNewCrumb } from "../../../../app/routes/utils/crumb-cache.js";
 import { createServer } from "../../../../app/server.js";
 import { getCrumbs } from "../../../utils/get-crumbs.js";
 import { setupViewClaimRender } from "../../../utils/view-claim-render-fixtures.js";
@@ -9,7 +8,6 @@ const { administrator, recommender } = permissions;
 
 jest.mock("../../../../app/api/applications");
 jest.mock("../../../../app/api/claims");
-jest.mock("../../../../app/routes/utils/crumb-cache");
 jest.mock("../../../../app/routes/utils/get-claim-view-states");
 jest.mock("../../../../app/auth");
 
@@ -94,7 +92,6 @@ describe("Recommended To Reject test", () => {
       };
       const res = await server.inject(options);
       expect(res.statusCode).toBe(StatusCodes.MOVED_TEMPORARILY);
-      expect(generateNewCrumb).toHaveBeenCalledTimes(1);
       expect(res.headers.location).toEqual(`/view-claim/${reference}?page=1&returnPage=claims`);
     });
   });

--- a/test/integration/narrow/routes/update-status.test.js
+++ b/test/integration/narrow/routes/update-status.test.js
@@ -11,7 +11,6 @@ const { administrator } = permissions;
 
 jest.mock("../../../../app/api/applications");
 jest.mock("../../../../app/api/claims");
-jest.mock("../../../../app/routes/utils/crumb-cache");
 jest.mock("../../../../app/routes/utils/get-claim-view-states");
 jest.mock("../../../../app/auth");
 


### PR DESCRIPTION
## Summary

Removes the last of the CSRF token rotation, so the crumb is now issued once per session and stays put.

Backoffice users can work with several tabs open, use the back button, or submit a bookmarked form without hitting a 403 and losing their input. The two preceding PRs put the replacement protections in place first, so nothing is left unguarded by this one.

Third and final PR on this workstream, and the one that closes the ticket. 

## What Changed

- Removed all nine calls that forced a new crumb, across the agreements list, claims list, claims clear, agreement detail, flags, PII redaction, claim data updates, withdrawal and the shared claim status-transition route builder.
- Deleted the crumb-cache module, which held nothing else after the previous PR.
- Dropped two tests that asserted a new crumb had been issued, and a stale module mock.
- Added a test file covering crumb behaviour: the token survives a re-render, a form submitted from an earlier page render is accepted, and a mismatched token is still rejected.

## Why

One cookie holds one token, shared by every tab. Rotating it meant only the most recently rendered page had a token matching the cookie, so any earlier page carried a stale value and its next POST was rejected. RPA staff routinely cross-reference agreements and claims across tabs, so they hit this in normal use, and production logs from 13 August show it happening three times in a single day.