### PR TITLE
chore(deps): (AHWR-2118) add Dependabot config and run SonarCloud scan on its PRs #patch

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,65 @@
+version: 2
+
+updates:
+  # Update npm packages
+  - package-ecosystem: npm
+    directory: /
+    open-pull-requests-limit: 10
+
+    # Group packages into shared PR
+    groups:
+      dev:
+        applies-to: "version-updates"
+        dependency-type: "development"
+        update-types:
+          - "minor"
+          - "patch"
+        patterns:
+          - "*"
+
+      prod:
+        applies-to: "version-updates"
+        dependency-type: "production"
+        update-types:
+          - "minor"
+          - "patch"
+        patterns:
+          - "*"
+
+      security:
+        applies-to: "security-updates"
+        patterns:
+          - "*"
+
+      other:
+        update-types:
+          - "minor"
+          - "patch"
+        patterns:
+          - "*"
+
+    # Schedule run nightly
+    schedule:
+      interval: "cron"
+      cronjob: "0 0 * * *"
+
+    cooldown:
+      default-days: 7
+
+    versioning-strategy: increase
+
+    allow:
+      # Include direct package.json updates
+      - dependency-type: direct
+
+  # Update GitHub Actions
+  - package-ecosystem: github-actions
+    directory: /
+
+    # Schedule run nightly
+    schedule:
+      interval: "cron"
+      cronjob: "0 0 * * *"
+
+    cooldown:
+      default-days: 7

--- a/.github/workflows/check-pull-request.yml
+++ b/.github/workflows/check-pull-request.yml
@@ -50,7 +50,6 @@ jobs:
           fi
 
       - name: SonarCloud Scan
-        if: github.actor != 'dependabot[bot]'
         uses: SonarSource/sonarqube-scan-action@v5.3.1 #  (or check latest version on https://github.com/marketplace/actions/official-sonarqube-scan)
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
Enables Dependabot for this repository and unblocks the Dependabot PRs it will raise. Config-only and CI-only changes; no runtime or test code is touched, so this is deploy-safe and independent of every other service.

## What Changed
- Add `.github/dependabot.yml` (Variant A - no global-agent). Nightly npm and github-actions update checks, grouped into prod/dev/security/other PRs, 7-day cooldown matching `.npmrc min-release-age`, 10 open-PR limit, direct dependencies only.
- Remove the `if: github.actor != 'dependabot[bot]'` guard from the SonarCloud Scan step in `check-pull-request.yml` so the scan runs on Dependabot PRs.

## Why
The ruleset requires the `SonarCloud Code Analysis` status check to pass before merge. Dependabot-triggered runs previously skipped the SonarCloud step, so that status never posted and every Dependabot PR would deadlock. Removing the guard lets the scan run; it reads `SONAR_TOKEN` from the repository's Dependabot secrets store (added out of band). Snyk already posts a passing status on Dependabot PRs, so it needed no change.