### PR TITLE
chore(deps): (AHWR-2118) ignore sass-loader majors pending Sass API migration #patch

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -48,6 +48,12 @@ updates:
 
     versioning-strategy: increase
 
+    ignore:
+      # sass-loader pinned to 12.x: 16+ switched to the modern Sass API, which breaks the current @import-based SCSS build (deferred migration)
+      - dependency-name: sass-loader
+        update-types:
+          - version-update:semver-major
+
   # Update GitHub Actions
   - package-ecosystem: github-actions
     directory: /


### PR DESCRIPTION
## Summary
Adds a Dependabot ignore rule that parks sass-loader on its current 12.x line, blocking all major-version bumps while leaving 12.x minor and patch updates flowing. sass-loader 16+ switched to the modern Sass API, which changes import resolution and breaks the current `@import`-based SCSS build, so the upgrade needs a deliberate migration rather than a routine Dependabot bump.

The migration itself is tracked as a follow-up: [AHWR-2216](https://eaflood.atlassian.net/browse/AHWR-2216) which removes this ignore rule as part of its work.

This is Dependabot configuration only - no runtime, test, or build impact.

## What Changed
- Added an `ignore` entry to the npm ecosystem in `.github/dependabot.yml` for `sass-loader`, scoped to `version-update:semver-major`.

## Why
The sass-loader major had already been parked once via a per-PR ignore comment, but Dependabot then offered the next major down (17 -> 16), and would keep walking down the majors. A config-level ignore stops that whack-a-mole in one place, and unlike a comment-ignore it is visible and auditable in the repository. It mirrors the existing `global-agent` ignore idiom used elsewhere in the estate.

## Follow-up
Removing this ignore rule is an explicit step in [AHWR-2216](https://eaflood.atlassian.net/browse/AHWR-2216) (the Sass API migration) and until that lands, sass-loader stays on 12.x.

[AHWR-2216]: https://eaflood.atlassian.net/browse/AHWR-2216?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AHWR-2216]: https://eaflood.atlassian.net/browse/AHWR-2216?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ