### PR TITLE
fix(auth): (AHWR-2118) migrate @hapi/cookie to v12 validate/isValid #patch

### DIFF
--- a/app/plugins/auth.js
+++ b/app/plugins/auth.js
@@ -28,14 +28,14 @@ export const authPlugin = {
         },
         keepAlive: false,
         redirectTo: "/login",
-        validateFunc: async (_request, session) => {
+        validate: async (_request, session) => {
           const sessionFromCache = await getSession(session.id);
           if (!sessionFromCache) {
-            return { valid: false };
+            return { isValid: false };
           }
 
           return {
-            valid: true,
+            isValid: true,
             credentials: {
               account: sessionFromCache.account,
               scope: sessionFromCache.scope,

--- a/app/plugins/auth.test.js
+++ b/app/plugins/auth.test.js
@@ -1,0 +1,82 @@
+import Hapi from "@hapi/hapi";
+import { StatusCodes } from "http-status-codes";
+import { authPlugin } from "./auth.js";
+import { getCacheEngine } from "../cache/get-cache-engine.js";
+
+const account = { name: "Tester", username: "tester@test" };
+const scope = ["administrator"];
+
+const cookieFrom = (response) => response.headers["set-cookie"][0].split(";")[0];
+
+const buildServer = async () => {
+  const server = Hapi.server({ cache: [getCacheEngine()] });
+  await server.register(authPlugin);
+
+  server.route({
+    method: "GET",
+    path: "/login",
+    options: { auth: false },
+    handler: async (request, h) => {
+      const sessionId = await server.plugins.auth.createSession(account, scope);
+      request.cookieAuth.set({ id: sessionId });
+      return h.response({ ok: true });
+    },
+  });
+
+  server.route({
+    method: "GET",
+    path: "/login-orphaned-session",
+    options: { auth: false },
+    handler: (request, h) => {
+      request.cookieAuth.set({ id: "session-not-in-cache" });
+      return h.response({ ok: true });
+    },
+  });
+
+  server.route({
+    method: "GET",
+    path: "/protected",
+    handler: (request) => request.auth.credentials,
+  });
+
+  await server.initialize();
+  return server;
+};
+
+describe("auth plugin session validation", () => {
+  let server;
+
+  beforeAll(async () => {
+    server = await buildServer();
+  });
+
+  afterAll(async () => {
+    await server.stop();
+  });
+
+  test("grants access when the session is in the cache and exposes account and scope as credentials", async () => {
+    const login = await server.inject({ method: "GET", url: "/login" });
+
+    const response = await server.inject({
+      method: "GET",
+      url: "/protected",
+      headers: { cookie: cookieFrom(login) },
+    });
+
+    expect(response.statusCode).toBe(StatusCodes.OK);
+    expect(JSON.parse(response.payload)).toEqual({ account, scope });
+  });
+
+  test("redirects to the login page when the session is no longer in the cache", async () => {
+    const login = await server.inject({ method: "GET", url: "/login-orphaned-session" });
+
+    const response = await server.inject({
+      method: "GET",
+      url: "/protected",
+      headers: { cookie: cookieFrom(login) },
+    });
+
+    expect(response.statusCode).toBe(StatusCodes.MOVED_TEMPORARILY);
+    expect(response.headers.location).toBe("/login");
+  });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "@hapi/boom": "10.0.1",
         "@hapi/catbox-memory": "6.0.2",
         "@hapi/catbox-redis": "7.0.2",
-        "@hapi/cookie": "11.0.2",
+        "@hapi/cookie": "12.0.1",
         "@hapi/crumb": "8.0.1",
         "@hapi/hapi": "21.4.10",
         "@hapi/inert": "7.1.2",
@@ -2187,24 +2187,41 @@
       }
     },
     "node_modules/@hapi/cookie": {
-      "version": "11.0.2",
-      "resolved": "https://registry.npmjs.org/@hapi/cookie/-/cookie-11.0.2.tgz",
-      "integrity": "sha512-LRpSuHC53urzml83c5eUHSPPt7YtK1CaaPZU9KmnhZlacVVojrWJzOUIcwOADDvCZjDxowCO3zPMaOqzEm9kgg==",
+      "version": "12.0.1",
+      "resolved": "https://registry.npmjs.org/@hapi/cookie/-/cookie-12.0.1.tgz",
+      "integrity": "sha512-TpykARUIgTBvgbsgtYe5CrM/7XBGms2/22JD3N6dzct6bG1vcOC6pH1JWIos1O5zvQnyDSJ2pnaFk+DToHkAng==",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@hapi/boom": "9.x.x",
-        "@hapi/bounce": "2.x.x",
-        "@hapi/hoek": "9.x.x",
-        "@hapi/validate": "1.x.x"
+        "@hapi/boom": "^10.0.1",
+        "@hapi/bounce": "^3.0.1",
+        "@hapi/hoek": "^11.0.2",
+        "@hapi/validate": "^2.0.1"
       }
     },
-    "node_modules/@hapi/cookie/node_modules/@hapi/boom": {
-      "version": "9.1.4",
-      "resolved": "https://registry.npmjs.org/@hapi/boom/-/boom-9.1.4.tgz",
-      "integrity": "sha512-Ls1oH8jaN1vNsqcaHVYJrKmgMcKsC1wcp8bujvXrHaAqD2iDYq3HoOwsxwo09Cuda5R5nC0o0IxlrlTuvPuzSw==",
+    "node_modules/@hapi/cookie/node_modules/@hapi/bounce": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@hapi/bounce/-/bounce-3.0.2.tgz",
+      "integrity": "sha512-d0XmlTi3H9HFDHhQLjg4F4auL1EY3Wqj7j7/hGDhFFe6xAbnm3qiGrXeT93zZnPH8gH+SKAFYiRzu26xkXcH3g==",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@hapi/hoek": "9.x.x"
+        "@hapi/boom": "^10.0.1",
+        "@hapi/hoek": "^11.0.2"
+      }
+    },
+    "node_modules/@hapi/cookie/node_modules/@hapi/hoek": {
+      "version": "11.0.7",
+      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-11.0.7.tgz",
+      "integrity": "sha512-HV5undWkKzcB4RZUusqOpcgxOaq6VOAH7zhhIr2g3G8NF/MlFO75SjOr2NfuSx0Mh40+1FqCkagKLJRykUWoFQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@hapi/cookie/node_modules/@hapi/validate": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@hapi/validate/-/validate-2.0.1.tgz",
+      "integrity": "sha512-NZmXRnrSLK8MQ9y/CMqE9WSspgB9xA41/LlYR0k967aSZebWr4yNrpxIbov12ICwKy4APSlWXZga9jN5p6puPA==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@hapi/hoek": "^11.0.2",
+        "@hapi/topo": "^6.0.1"
       }
     },
     "node_modules/@hapi/crumb": {

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "@hapi/boom": "10.0.1",
     "@hapi/catbox-memory": "6.0.2",
     "@hapi/catbox-redis": "7.0.2",
-    "@hapi/cookie": "11.0.2",
+    "@hapi/cookie": "12.0.1",
     "@hapi/crumb": "8.0.1",
     "@hapi/hapi": "21.4.10",
     "@hapi/inert": "7.1.2",


### PR DESCRIPTION
## Summary

Adapts the cookie auth strategy to @hapi/cookie v12, which renames the session validation option and changes its expected return shape. This unblocks the Dependabot bump of @hapi/cookie from 11.0.2 to 12.0.1, which cannot merge on its own because v12 rejects the old option name. Adds the previously missing test coverage for the validator.

## What Changed

- Renamed the cookie strategy's `validateFunc` option to `validate`.
- Changed the validator's returns from `{ valid }` to `{ isValid }` to match v12's contract.
- Bumped `@hapi/cookie` from 11.0.2 to 12.0.1.
- Added a plugin test covering both the valid-session (returns account and scope as credentials) and orphaned-session (redirect to login) paths.

## Why

@hapi/cookie v12 removed `validateFunc` (now `validate`) and renamed the return property `valid` to `isValid`. The old names throw a validation error at strategy registration, so the dependency bump and this code change must land together. The validator previously had no direct test coverage, so the changed lines would otherwise be uncovered new code; the new test closes that gap and asserts the credentials contract. Auth behaviour is unchanged. Supersedes the standalone Dependabot bump PR, which should be closed.