### PR TITLE
fix: (AHWR-2223) restore readable text on confirmation panels #patch

### DIFF
--- a/app/frontend/src/css/application.scss
+++ b/app/frontend/src/css/application.scss
@@ -247,6 +247,7 @@ a.pagination__link:focus {
   background-color: #fafafa;
   border-color: #000000;
   border-width: medium;
+  --govuk-text-colour: #0b0c0c;
   h1 {
     color: #000000;
   }


### PR DESCRIPTION
## Summary
Restores dark, readable text on the claim-action confirmation panels.

The checkbox confirmation text on every "confirm and continue" panel (Authorise, Reject, Recommend to Pay/Reject, Move to In Check, the update forms, Create/Delete flag) was rendering white against the app's light-gray panel background, giving near-zero contrast and leaving only the panel title legible.

## What Changed
- Reset the `--govuk-text-colour` custom property to a dark value within the `.govuk-panel--confirmation` override in `application.scss`.

## Why
The app repurposes govuk-frontend's confirmation panel into a light-background box, overriding the background and the title colour but not the body text colour. govuk-frontend 6.4.0 moved colour handling onto CSS custom properties: the confirmation panel sets `--govuk-text-colour` to its inverse (white) on the assumption of a dark background, and the checkbox labels now inherit that value instead of carrying their own colour. With the background overridden to light, that white text became invisible. Resetting the custom property on the panel restores dark text for all descendants (labels and currentColor borders) in one place, fixing all affected panels at once. The defect pre-dates this change (inherited from the pre-CDP codebase) and was surfaced, not caused, by the govuk-frontend upgrade.

## Screenshot
<img width="1326" height="818" alt="Screenshot 2026-08-24 at 16 44 19" src="https://github.com/user-attachments/assets/689bafdb-1326-44af-8ebc-979209f7c638" />

