### PR TITLE
chore(deps): (AHWR-2118) ignore ioredis majors pending catbox-redis support #patch

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -53,6 +53,10 @@ updates:
       - dependency-name: sass-loader
         update-types:
           - version-update:semver-major
+      # ioredis pinned to 5.x: @hapi/catbox-redis 7.0.2 peers ioredis ^5; revisit when catbox-redis accepts ^6
+      - dependency-name: ioredis
+        update-types:
+          - version-update:semver-major
 
   # Update GitHub Actions
   - package-ecosystem: github-actions


### PR DESCRIPTION
## Summary
Adds a Dependabot ignore rule that parks ioredis on its current 5.x line, blocking major-version bumps while leaving 5.x minor and patch updates flowing. ioredis 6 cannot be adopted yet because `@hapi/catbox-redis@7.0.2` declares a peer dependency of `ioredis: ^5`, so bumping to 6 would create a peer conflict. This is Dependabot configuration only - no runtime, test, or build impact.

## What Changed
- Added an `ignore` entry to the npm ecosystem in `.github/dependabot.yml` for `ioredis`, scoped to `version-update:semver-major`.

## Why
The ioredis 6 major is blocked upstream, not by anything in this repo: catbox-redis (which backs the session cache via an app-provided ioredis client) peers `ioredis ^5`. Until catbox-redis ships a release that accepts ioredis 6, the upgrade cannot go in. A config-level ignore stops Dependabot repeatedly raising a PR that can only sit peer-conflicted, and unlike a comment-ignore it is visible and auditable in the repository, with the blocking condition recorded inline. It mirrors the existing sass-loader and global-agent ignore idioms.